### PR TITLE
feat(demo): 3 cenários selecionáveis — leads, fluxo de caixa e atendimento

### DIFF
--- a/docs/leads-analytics.md
+++ b/docs/leads-analytics.md
@@ -68,6 +68,7 @@ Se o webhook falhar, a API devolve 502 e o form oferece o fallback por e-mail
 | `jornada_hitl_ok` | Aprovou a 1ª ação do assistente | — |
 | `jornada_publish` | Publicou o app para o time | — |
 | `jornada_done` | Jornada completa (evoluiu por conversa) | — |
+| `jornada_recomecar` | Reiniciou a demo pela topbar (escolher outro exemplo) | `cenario` (o que estava ativo) |
 | `jornada_beta_click` | CTA ao fim da jornada | — |
 | `beta_form_submitted` / `beta_form_error` | Form do beta | — |
 

--- a/docs/leads-analytics.md
+++ b/docs/leads-analytics.md
@@ -61,8 +61,8 @@ Se o webhook falhar, a API devolve 502 e o form oferece o fallback por e-mail
 | `demo_ops_run` | Visitante iniciou o Ato 2 (operar) | `scenario` |
 | `demo_ops_done` | Ato 2 concluído — o momento de convicção | `scenario` |
 | `demo_beta_click` / `demo_contact_click` | CTA ao fim da demo | — |
-| `jornada_start` | Iniciou a jornada interativa (/demo) | `entry` (planilha \| prosa) |
-| `jornada_stage` | Avançou de etapa na jornada | `stage` (0-7), `label` |
+| `jornada_start` | Iniciou a jornada interativa (/demo) | `entry` (planilha \| prosa-livre), `cenario` (leads \| caixa \| atendimento) |
+| `jornada_stage` | Avançou de etapa na jornada | `stage` (0-7), `label`, `cenario` (leads \| caixa \| atendimento) |
 | `jornada_touch` | Operou o rascunho vivo (1ª interação no app) | — |
 | `jornada_keep` | "Ficar com ele" — aprovou vendo (convicção) | — |
 | `jornada_hitl_ok` | Aprovou a 1ª ação do assistente | — |

--- a/src/components/JourneyDemo.tsx
+++ b/src/components/JourneyDemo.tsx
@@ -11,13 +11,18 @@ import { track } from '@/lib/analytics';
    Diferente da demo narrada da home (DemoBuilder, dois atos), aqui o
    visitante dirige: escolhe um cenário (ou descreve em prosa), entrega
    uma planilha de exemplo, vê o espelho, corrige premissas, manda montar
-   — e recebe um RASCUNHO VIVO que ele opera (kanban, tabela, ficha) ANTES
-   de decidir "ficar com ele". Aprova o que vê, não uma lista técnica.
+   — e recebe um RASCUNHO VIVO que ele opera ANTES de decidir "ficar com
+   ele". Aprova o que vê, não uma lista técnica.
 
-   São 3 cenários (leads · fluxo de caixa · atendimento). Todo o conteúdo
-   variável vive no registro CENARIOS; a mecânica é a mesma para os três.
-   O cenário ativo fica em cenarioRef (síncrona) para o replay determinístico
-   — voltar re-executa O MESMO cenário.
+   São 3 cenários, e CADA UM materializa uma SUPERFÍCIE diferente — a tese
+   "o software se molda ao seu negócio" tem que ser vista, não afirmada:
+     · leads       → kanban (pipeline é a forma natural)
+     · caixa       → financeiro (faixa de indicadores + tabela de faturas)
+     · atendimento → chats (fila + conversa estilo WhatsApp; o assistente
+                     EXECUTA — agenda, confirma, encaminha o clínico)
+   Todo o conteúdo variável vive no registro CENARIOS; a mecânica (locks,
+   autopilot, replay) é a mesma. O cenário ativo fica em cenarioRef
+   (síncrona) para o replay determinístico — voltar re-executa O MESMO.
 
    As 5 regras da confiança (messages.ts) acendem nos momentos em que
    acontecem — a message house demonstrada, não afirmada.
@@ -38,9 +43,9 @@ const STAGES = [
   'Evoluir',
 ] as const;
 
-type LogE = { who: 'user' | 'agent'; text: string; time: string };
+type LogE = { who: 'user' | 'agent' | 'system'; text: string; time: string };
 
-type NBA = { text: string; kind?: 'advance' | 'handoff'; log?: string };
+type NBA = { text: string; kind?: 'advance' | 'handoff' | 'note'; log?: string };
 
 type Registro = {
   id: string;
@@ -51,9 +56,10 @@ type Registro = {
   agent?: boolean;
   log: LogE[];
   nba?: NBA;
+  nbaDone?: boolean;
 };
 
-type Seed = { id: string; name: string; meta: Record<string, string>; stage: string; nba?: NBA };
+type Seed = { id: string; name: string; meta: Record<string, string>; stage: string; nba?: NBA; thread?: LogE[] };
 
 type CardId =
   | 'espelho'
@@ -81,6 +87,22 @@ function boldify(text: string): ReactNode {
   return text.split(/\*\*(.+?)\*\*/g).map((p, i) => (i % 2 === 1 ? <b key={i}>{p}</b> : p));
 }
 
+// cor por status — pill colorida nas superfícies financeiro e chats
+const STATUS_COLOR: Record<string, string> = {
+  Novo: 'blue',
+  'Em atendimento': 'amber',
+  'Aguardando paciente': 'violet',
+  Resolvido: 'green',
+  'A vencer': 'blue',
+  Vencida: 'red',
+  'Em negociação': 'amber',
+  Acordo: 'violet',
+  Paga: 'green',
+};
+
+const brl = (n: number) => 'R$ ' + n.toLocaleString('pt-BR');
+const valOf = (r: Registro) => Number((r.meta.valor ?? '0').replace(/[^\d]/g, ''));
+
 const INITIAL_ITEMS: Item[] = [
   {
     kind: 'msg',
@@ -92,6 +114,7 @@ const INITIAL_ITEMS: Item[] = [
 // ======================= CENÁRIOS =======================
 
 type CenarioId = 'leads' | 'caixa' | 'atendimento';
+type Surface = 'kanban' | 'financeiro' | 'chats';
 
 type Premissa =
   | { icon: string; text: string }
@@ -120,6 +143,7 @@ type TableCol = {
 
 type Cenario = {
   id: CenarioId;
+  surface: Surface;
   pill: string;
   tema: string; // roteiro do texto livre
   // entrada
@@ -137,13 +161,14 @@ type Cenario = {
   columns: string[];
   extraN: number;
   seed: Seed[];
+  touchId?: string; // superfícies financeiro/chats: id aberto no autopilot (checkpoint 4)
   autoMove: { id: string; toStage: string; log: string };
   nbaDefault: (r: Registro) => NBA;
   // app
   appTitle: string;
   boardLabel: string;
   ctaObj: string;
-  // render dos registros
+  // render dos registros (kanban/financeiro)
   subtitle: (r: Registro) => string;
   recordFields: (r: Registro) => Field[];
   tableCols: TableCol[];
@@ -154,31 +179,34 @@ type Cenario = {
     build: (v: string[]) => { name: string; meta: Record<string, string> };
   };
   // magia / operar
-  magic: string; // fala depois de montar
-  touchHint: string; // pedido para mexer antes de decidir
+  magic: string;
+  touchHint: string;
   // HITL
   hitl: {
     text: string;
     button: string;
     note: string;
-    lead: string; // primeira frase do assistente depois de aprovar
+    lead: string;
     resolveLabel: string;
     apply: { id: string; toStage: string; log: string };
   };
-  // evoluir
+  // evoluir — por superfície: coluna (kanban) · status+move (financeiro) · regra (chats)
   evolve: {
     userMsg: string;
-    col: string;
-    before: string;
     allyViaChat: string;
     doneLabel: string;
+    col?: string;
+    before?: string;
+    move?: { id: string; from: string; to: string; log: string };
+    regra?: string;
   };
 };
 
 const CENARIOS: Record<CenarioId, Cenario> = {
-  // ---------------------------------------------------------------- LEADS
+  // ---------------------------------------------------------------- LEADS (kanban)
   leads: {
     id: 'leads',
+    surface: 'kanban',
     pill: '📊 Leads e contratos — hoje é planilha',
     tema: 'leads e contratos',
     xlsx: 'leads-criadores.xlsx (3 abas · 25 linhas)',
@@ -285,9 +313,10 @@ const CENARIOS: Record<CenarioId, Cenario> = {
     },
   },
 
-  // ---------------------------------------------------------------- CAIXA
+  // ---------------------------------------------------------------- CAIXA (financeiro)
   caixa: {
     id: 'caixa',
+    surface: 'financeiro',
     pill: '💰 Contas a receber e cobrança — hoje é planilha',
     tema: 'contas a receber e cobrança',
     xlsx: 'contas-a-receber.xlsx (2 abas · 22 linhas)',
@@ -331,17 +360,18 @@ const CENARIOS: Record<CenarioId, Cenario> = {
         name: 'TechFin',
         stage: 'A vencer',
         meta: { valor: 'R$ 12.400', venc: 'vence amanhã', email: 'financeiro@techfin.com', cnpj: '11.222.333/0001-81' },
-        nba: { text: 'Lembrete amigável — a fatura vence amanhã.' },
+        nba: { text: 'Lembrete amigável — a fatura vence amanhã.', kind: 'note', log: 'Lembrete enviado ✓ — a fatura vence amanhã.' },
       },
       { id: 'agro', name: 'AgroData', stage: 'Vencida', meta: { valor: 'R$ 8.900', venc: 'vencida há 12 dias', email: 'financeiro@agrodata.io', cnpj: '44.555.666/0001-72' } },
       { id: 'finops', name: 'FinOps Lab', stage: 'Em negociação', meta: { valor: 'R$ 21.000', venc: 'em negociação', email: 'contas@finopslab.com', cnpj: '77.888.999/0001-63' } },
       { id: 'eduplay', name: 'EduPlay', stage: 'A vencer', meta: { valor: 'R$ 5.600', venc: 'vence em 6 dias', email: 'financeiro@eduplay.com', cnpj: '22.333.444/0001-54' } },
       { id: 'healthhub', name: 'HealthHub', stage: 'Vencida', meta: { valor: 'R$ 3.100', venc: 'vencida há 3 dias', email: 'financeiro@healthhub.co', cnpj: '55.666.777/0001-45' } },
     ],
+    touchId: 'techfin',
     autoMove: { id: 'healthhub', toStage: 'Em negociação', log: 'Assistente priorizou a cobrança — próximo passo sugerido' },
-    nbaDefault: () => ({ text: 'Enviar o próximo toque da régua — acompanhar o vencimento.' }),
+    nbaDefault: () => ({ text: 'Enviar o próximo toque da régua — acompanhar o vencimento.', kind: 'note', log: 'Lembrete enviado ✓ — acompanhando o vencimento.' }),
     appTitle: 'Contas a Receber',
-    boardLabel: 'Recebíveis',
+    boardLabel: 'Faturas',
     ctaObj: 'uma cobrança',
     subtitle: (r) => `${r.meta.valor} · ${r.meta.venc}`,
     recordFields: (r) => [
@@ -356,7 +386,7 @@ const CENARIOS: Record<CenarioId, Cenario> = {
     tableCols: [
       { header: 'Cliente', get: (r) => r.name, primary: true },
       { header: 'Valor', get: (r) => r.meta.valor },
-      { header: 'CNPJ', get: (r) => maskCNPJ(r.meta.cnpj), lock: true },
+      { header: 'Vencimento', get: (r) => r.meta.venc },
       { header: 'Status', stage: true },
     ],
     newForm: {
@@ -378,8 +408,8 @@ const CENARIOS: Record<CenarioId, Cenario> = {
       }),
     },
     magic:
-      'As faturas da planilha já estão na tela. Mexe à vontade: clique num cliente, crie uma fatura, mova um card.',
-    touchHint: 'move uma fatura, abre uma ficha',
+      'As faturas da planilha já estão na tela, com o total em risco no topo. Mexe à vontade: clique num stat pra filtrar, abra uma fatura.',
+    touchHint: 'abre uma fatura ou clica num indicador pra filtrar',
     hitl: {
       text: 'A fatura da **AgroData (R$ 8.900)** está 12 dias vencida. Preparei a cobrança com proposta de parcelamento em 2x — envio?',
       button: 'Aprovar envio',
@@ -392,15 +422,17 @@ const CENARIOS: Record<CenarioId, Cenario> = {
       userMsg: 'Adiciona a etapa Acordo antes de Paga.',
       col: 'Acordo',
       before: 'Paga',
+      move: { id: 'finops', from: 'Em negociação', to: 'Acordo', log: 'Movida para Acordo — parcelamento combinado com o cliente' },
       allyViaChat:
-        'É assim que se evolui — pedindo. Nesta demonstração eu aplico um exemplo pronto: a etapa Acordo antes de Paga. Olha o quadro:',
-      doneLabel: 'etapa Acordo no quadro',
+        'É assim que se evolui — pedindo. Nesta demonstração eu aplico um exemplo pronto: o status Acordo antes de Paga. Olha o painel:',
+      doneLabel: 'status Acordo na régua',
     },
   },
 
-  // ---------------------------------------------------------------- ATENDIMENTO
+  // ---------------------------------------------------------------- ATENDIMENTO (chats)
   atendimento: {
     id: 'atendimento',
+    surface: 'chats',
     pill: '📅 Atendimento no WhatsApp que resolve — agenda lotada de mensagens',
     tema: 'atendimento no WhatsApp',
     xlsx: 'pacientes.xlsx (2 abas · 20 linhas)',
@@ -432,33 +464,71 @@ const CENARIOS: Record<CenarioId, Cenario> = {
     buildSteps: [
       'Guardando seus dados — 15 pacientes, agenda, conversas',
       'Protegendo CPF e dados de saúde no mesmo ato — nada nasce desprotegido',
-      'Montando sua tela de atendimento',
+      'Montando sua fila de conversas',
       'Ligando o assistente e as confirmações automáticas',
       'Conferindo tudo por dentro — cada peça bate com o desenho',
     ],
     columns: ['Novo', 'Em atendimento', 'Aguardando paciente', 'Resolvido'],
     extraN: 8,
     seed: [
-      { id: 'marina', name: 'Marina Lopes', stage: 'Novo', meta: { pedido: 'quer remarcar para quinta', cpf: '123.456.789-01' } },
-      { id: 'jose', name: 'José Neto', stage: 'Novo', meta: { pedido: 'primeira consulta, pediu horário', cpf: '234.567.890-12' } },
+      {
+        id: 'marina',
+        name: 'Marina Lopes',
+        stage: 'Novo',
+        meta: { pedido: 'quer remarcar para quinta', cpf: '123.456.789-01' },
+        thread: [
+          { who: 'user', text: 'Oi, preciso remarcar minha consulta 🙏', time: '09:12' },
+          { who: 'user', text: 'Consigo passar para quinta?', time: '09:12' },
+        ],
+        nba: { text: 'Remarcar para quinta às 14h e confirmar no calendário.', kind: 'advance', log: 'Pronto! Remarquei para quinta, 14h ✓ Já atualizei sua agenda.' },
+      },
+      {
+        id: 'jose',
+        name: 'José Neto',
+        stage: 'Novo',
+        meta: { pedido: 'primeira consulta, pediu horário', cpf: '234.567.890-12' },
+        thread: [
+          { who: 'user', text: 'Oi, queria marcar primeira consulta', time: '10:03' },
+          { who: 'agent', text: 'Claro! Tenho amanhã às 10h ou quinta às 14h. Qual fica melhor?', time: '10:03' },
+          { who: 'user', text: 'Amanhã 10h', time: '10:05' },
+        ],
+      },
       {
         id: 'paula',
         name: 'Paula Reis',
         stage: 'Em atendimento',
         meta: { pedido: 'perguntou sobre resultado de exame', cpf: '345.678.901-23' },
+        thread: [{ who: 'user', text: 'Oi, saiu o resultado do meu exame de sangue?', time: '11:20' }],
         nba: {
-          text: 'Assunto clínico detectado — não respondo isso: passo para a equipe agora.',
+          text: 'Assunto clínico — o assistente não responde: encaminhar para a equipe agora.',
           kind: 'handoff',
-          log: 'Encaminhado para humano — assunto clínico nunca fica com o assistente',
+          log: '🙋 Assunto clínico — o assistente não responde: encaminhado para a equipe.',
         },
       },
-      { id: 'carlos', name: 'Carlos Dias', stage: 'Aguardando paciente', meta: { pedido: 'confirmar presença amanhã', cpf: '456.789.012-34' } },
-      { id: 'rita', name: 'Rita Souza', stage: 'Novo', meta: { pedido: 'dúvida de convênio', cpf: '567.890.123-45' } },
+      {
+        id: 'carlos',
+        name: 'Carlos Dias',
+        stage: 'Aguardando paciente',
+        meta: { pedido: 'confirmar presença amanhã', cpf: '456.789.012-34' },
+        thread: [
+          { who: 'agent', text: 'Olá, Carlos! Passando para lembrar da sua consulta amanhã às 15h. Confirma presença?', time: '08:30' },
+          { who: 'user', text: 'Confirmo, estarei lá 👍', time: '08:41' },
+          { who: 'agent', text: 'Perfeito, presença confirmada ✓ Até amanhã!', time: '08:41' },
+        ],
+      },
+      {
+        id: 'rita',
+        name: 'Rita Souza',
+        stage: 'Novo',
+        meta: { pedido: 'dúvida de convênio', cpf: '567.890.123-45' },
+        thread: [{ who: 'user', text: 'Vocês atendem pelo convênio Unimed?', time: '14:02' }],
+      },
     ],
-    autoMove: { id: 'rita', toStage: 'Em atendimento', log: 'Assistente respondeu a dúvida de convênio — próximo passo sugerido' },
-    nbaDefault: () => ({ text: 'Responder e agendar — o assistente resolve e confirma.' }),
+    touchId: 'jose',
+    autoMove: { id: 'rita', toStage: 'Em atendimento', log: 'Sim, atendemos Unimed! Quer que eu já agende? ✓' },
+    nbaDefault: () => ({ text: 'Responder e agendar — o assistente resolve e confirma.', kind: 'advance', log: 'Respondido e encaminhado ✓' }),
     appTitle: 'Atendimento — WhatsApp',
-    boardLabel: 'Conversas',
+    boardLabel: 'Fila',
     ctaObj: 'um atendimento',
     subtitle: (r) => r.meta.pedido,
     recordFields: (r) => [
@@ -471,7 +541,6 @@ const CENARIOS: Record<CenarioId, Cenario> = {
     tableCols: [
       { header: 'Paciente', get: (r) => r.name, primary: true },
       { header: 'Pedido', get: (r) => r.meta.pedido },
-      { header: 'CPF', get: (r) => maskCPF(r.meta.cpf), lock: true },
       { header: 'Status', stage: true },
     ],
     newForm: {
@@ -488,23 +557,22 @@ const CENARIOS: Record<CenarioId, Cenario> = {
       }),
     },
     magic:
-      'As conversas da planilha já estão na tela. Mexe à vontade: clique num nome, abra uma conversa, mova um card.',
-    touchHint: 'move uma conversa, abre uma ficha',
+      'As conversas da planilha já estão na fila. Mexe à vontade: abra uma conversa e veja o assistente atendendo — ele agenda, confirma e passa o clínico pra equipe.',
+    touchHint: 'abre uma conversa da fila',
     hitl: {
       text: 'O **José pediu primeira consulta amanhã às 10h** — a agenda está livre. Confirmo o agendamento?',
       button: 'Confirmar agendamento',
       note: 'Você aprovou: consulta do José confirmada',
       lead: 'Consulta confirmada.',
       resolveLabel: 'Você confirmou o agendamento',
-      apply: { id: 'jose', toStage: 'Aguardando paciente', log: 'Consulta confirmada e agendada — aprovada por você' },
+      apply: { id: 'jose', toStage: 'Aguardando paciente', log: 'Agendado! Amanhã às 10h ✓ Confirmação enviada.' },
     },
     evolve: {
-      userMsg: 'Adiciona a coluna Confirmação antes de Resolvido.',
-      col: 'Confirmação',
-      before: 'Resolvido',
+      userMsg: 'Liga a confirmação automática na véspera.',
+      regra: '🔔 confirma véspera ✓',
       allyViaChat:
-        'É assim que se evolui — pedindo. Nesta demonstração eu aplico um exemplo pronto: a coluna Confirmação antes de Resolvido. Olha o quadro:',
-      doneLabel: 'coluna Confirmação no quadro',
+        'É assim que se evolui — pedindo. Nesta demonstração eu ligo um exemplo pronto: confirmação automática na véspera. Olha as regras do atendimento:',
+      doneLabel: 'confirmação automática na véspera',
     },
   },
 };
@@ -531,6 +599,7 @@ export default function JourneyDemo() {
   const [view, setView] = useState<'kanban' | 'table' | 'record'>('kanban');
   const [recordId, setRecordId] = useState<string | null>(null);
   const [query, setQuery] = useState('');
+  const [statFilter, setStatFilter] = useState<'aberto' | 'vencido' | 'neg' | null>(null);
   const [draft, setDraft] = useState<'none' | 'building' | 'draft' | 'kept' | 'published'>('none');
   const [trust, setTrust] = useState<boolean[]>([false, false, false, false, false]);
   const [evolveState, setEvolveState] = useState<'none' | 'applied' | 'undone'>('none');
@@ -619,7 +688,6 @@ export default function JourneyDemo() {
   };
 
   // ---------------- E0: entrada ----------------
-  // Aplica o cenário escolhido (pill ou roteamento) — antes de começar.
   const aplicarCenario = (id: CenarioId) => {
     cenarioRef.current = id;
     setCenarioId(id);
@@ -701,10 +769,16 @@ export default function JourneyDemo() {
     }
     const arquivo = c.xlsx.split(' ')[0];
     const seeded: Registro[] = c.seed.map((s) => ({
-      ...s,
+      id: s.id,
+      name: s.name,
+      meta: s.meta,
+      stage: s.stage,
+      nba: s.nba,
       origem: 'da sua planilha',
       agent: false,
-      log: [{ who: 'user', text: `Importado da planilha ${arquivo}`, time: '14:31' }],
+      log: s.thread
+        ? s.thread.map((e) => ({ ...e }))
+        : [{ who: 'user', text: `Importado da planilha ${arquivo}`, time: '14:31' }],
     }));
     setRecords(seeded);
     setDraft('draft');
@@ -751,8 +825,8 @@ export default function JourneyDemo() {
   async function ajustar() {
     if (!lock('ajustar')) return;
     const c = CENARIOS[cenarioRef.current];
-    const alvo = c.columns[2]; // 3ª coluna do funil — reordenada para logo depois da 1ª
-    push({ kind: 'msg', who: 'user', text: `Queria a coluna de ${alvo} logo depois de ${c.columns[0]}.` });
+    const alvo = c.columns[2];
+    push({ kind: 'msg', who: 'user', text: `Queria ${alvo} logo depois de ${c.columns[0]}.` });
     await ally('Troquei — olha a tela. Ajustar rascunho é conversa, não retrabalho. É isso?', 500);
     setStagesK((p) => {
       const rest = p.filter((s) => s !== alvo);
@@ -769,6 +843,14 @@ export default function JourneyDemo() {
   async function aprovaEnvio() {
     if (!lock('hitl')) return;
     const c = CENARIOS[cenarioRef.current];
+    // deixa o momento visível: financeiro volta pra tabela (o stat cai);
+    // chats abre a conversa (a bolha de confirmação aparece na thread)
+    if (c.surface === 'financeiro') {
+      setView('kanban');
+    } else if (c.surface === 'chats') {
+      setRecordId(c.hitl.apply.id);
+      setView('record');
+    }
     resolveCard('hitl', c.hitl.resolveLabel);
     earn(3); // Humano assume
     track('jornada_hitl_ok');
@@ -805,16 +887,31 @@ export default function JourneyDemo() {
   async function aplicarEvolucao(viaChat?: string) {
     if (!lock('evo')) return;
     const c = CENARIOS[cenarioRef.current];
-    push({ kind: 'msg', who: 'user', text: viaChat ?? c.evolve.userMsg });
-    if (viaChat) await ally(c.evolve.allyViaChat, 550);
+    const ev = c.evolve;
+    push({ kind: 'msg', who: 'user', text: viaChat ?? ev.userMsg });
+    if (viaChat) await ally(ev.allyViaChat, 550);
     await delay(450);
-    setStagesK((p) => {
-      if (p.includes(c.evolve.col)) return p;
-      const i = p.indexOf(c.evolve.before);
-      const cp = [...p];
-      cp.splice(i, 0, c.evolve.col);
-      return cp;
-    });
+    if (ev.col && ev.before) {
+      const col = ev.col;
+      const before = ev.before;
+      setStagesK((p) => {
+        if (p.includes(col)) return p;
+        const i = p.indexOf(before);
+        const cp = [...p];
+        cp.splice(i < 0 ? cp.length : i, 0, col);
+        return cp;
+      });
+    }
+    if (ev.move) {
+      const mv = ev.move;
+      setRecords((p) =>
+        p.map((r) =>
+          r.id === mv.id
+            ? { ...r, stage: mv.to, agent: true, log: [...r.log, { who: 'agent', text: mv.log, time: now() }] }
+            : r,
+        ),
+      );
+    }
     setEvolveState('applied');
     await ally('Aplicado ✓ — mudança simples não pede cerimônia. E tem Desfazer, porque errar não pode machucar.', 500);
     track('jornada_done');
@@ -823,7 +920,12 @@ export default function JourneyDemo() {
 
   function desfazer() {
     const c = CENARIOS[cenarioRef.current];
-    setStagesK((p) => p.filter((s) => s !== c.evolve.col));
+    const ev = c.evolve;
+    if (ev.col) setStagesK((p) => p.filter((s) => s !== ev.col));
+    if (ev.move) {
+      const mv = ev.move;
+      setRecords((p) => p.map((r) => (r.id === mv.id ? { ...r, stage: mv.from } : r)));
+    }
     setEvolveState('undone');
     earn(2); // Correção + desfazer
   }
@@ -867,7 +969,9 @@ export default function JourneyDemo() {
     () => montaRascunho(),
     async () => {
       if (!touchedRef.current) {
-        moveRecord(CENARIOS[cenarioRef.current].seed[0].id);
+        const c = CENARIOS[cenarioRef.current];
+        if (c.surface === 'kanban') moveRecord(c.seed[0].id);
+        else openRecord(c.touchId ?? c.seed[0].id);
         await delay(650);
       }
       await ficarComEle();
@@ -926,6 +1030,7 @@ export default function JourneyDemo() {
     setView('kanban');
     setRecordId(null);
     setQuery('');
+    setStatFilter(null);
     setDraft('none');
     setTrust([false, false, false, false, false]);
     setEvolveState('none');
@@ -973,19 +1078,19 @@ export default function JourneyDemo() {
     const c = CENARIOS[cenarioRef.current];
     const base = c.newForm.build(vals);
     const id = 'novo-' + Date.now().toString(36);
+    const log: LogE[] =
+      c.surface === 'chats'
+        ? [{ who: 'user', text: base.meta.pedido, time: now() }]
+        : [{ who: 'user', text: 'Criado por você, direto na tela do rascunho', time: now() }];
     setRecords((p) => [
       ...p,
-      {
-        id,
-        name: base.name,
-        meta: base.meta,
-        stage: stagesK[0],
-        origem: 'criado por você',
-        agent: false,
-        log: [{ who: 'user', text: 'Criado por você, direto na tela do rascunho', time: now() }],
-      },
+      { id, name: base.name, meta: base.meta, stage: stagesK[0], origem: 'criado por você', agent: false, log },
     ]);
     setNewOpen(false);
+    markTouched();
+  }
+  function statClick(kind: 'aberto' | 'vencido' | 'neg') {
+    setStatFilter((p) => (p === kind ? null : kind));
     markTouched();
   }
   function nbaAction(id: string) {
@@ -995,13 +1100,16 @@ export default function JourneyDemo() {
         if (r.id !== id) return r;
         const nba = r.nba ?? c.nbaDefault(r);
         if (nba.kind === 'handoff') {
-          return { ...r, log: [...r.log, { who: 'agent', text: nba.log ?? 'Encaminhado para um humano', time: now() }] };
+          return { ...r, nbaDone: true, log: [...r.log, { who: 'system', text: nba.log ?? 'Encaminhado para um humano', time: now() }] };
+        }
+        if (nba.kind === 'note') {
+          return { ...r, nbaDone: true, agent: true, log: [...r.log, { who: 'agent', text: nba.log ?? 'Feito ✓', time: now() }] };
         }
         const i = stagesK.indexOf(r.stage);
         const next = i >= 0 && i < stagesK.length - 1 ? stagesK[i + 1] : r.stage;
         return {
-          ...r, stage: next, agent: true,
-          log: [...r.log, { who: 'agent', text: 'Próximo passo executado pelo assistente — com o seu OK', time: now() }],
+          ...r, stage: next, agent: true, nbaDone: true,
+          log: [...r.log, { who: 'agent', text: nba.log ?? 'Próximo passo executado pelo assistente — com o seu OK', time: now() }],
         };
       }),
     );
@@ -1015,6 +1123,13 @@ export default function JourneyDemo() {
   const filtered = records.filter((r) =>
     (r.name + ' ' + cen.subtitle(r)).toLowerCase().includes(query.toLowerCase()),
   );
+  const statusPill = (s: string) =>
+    cen.surface === 'kanban' ? (
+      <span className="jd-stagepill">{s}</span>
+    ) : (
+      <span className={'jd-spill jd-spill-' + (STATUS_COLOR[s] ?? 'blue')}>{s}</span>
+    );
+  const lastMsg = (r: Registro) => r.log[r.log.length - 1];
 
   function renderCard(item: Extract<Item, { kind: 'card' }>) {
     const done = item.resolved;
@@ -1174,6 +1289,205 @@ export default function JourneyDemo() {
     }
   }
 
+  // ---- superfície: KANBAN (leads) ----
+  function renderKanban() {
+    return (
+      <div className="jd-kanban">
+        {stagesK.map((s) => {
+          const col = records.filter((l) => l.stage === s);
+          const extra = s === entryCol ? cen.extraN : 0;
+          return (
+            <div key={s} className="jd-kcol">
+              <div className="jd-khead">{s}<span>{col.length + extra}</span></div>
+              {col.map((l) => (
+                <div key={l.id} className="jd-kcard">
+                  <button className="jd-kname" onClick={() => openRecord(l.id)}>{l.name}</button>
+                  <div className="jd-ksub">{cen.subtitle(l)}</div>
+                  <div className="jd-kfoot">
+                    <span className={'jd-ktag' + (l.agent ? ' ag' : '')}>{l.agent ? 'assistente moveu' : l.origem}</span>
+                    <button className="jd-kmove" onClick={() => moveRecord(l.id)} aria-label={`Mover ${l.name}`}>mover →</button>
+                  </div>
+                </div>
+              ))}
+              {s === entryCol && (
+                <>
+                  {extra > 0 && <div className="jd-kmore">+{extra} da planilha</div>}
+                  <button className="jd-kadd" onClick={() => setNewOpen(true)}>{cen.newForm.add}</button>
+                </>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    );
+  }
+
+  // ---- superfície: FINANCEIRO (caixa) ----
+  function renderFinanceiro() {
+    const emAberto = records.filter((r) => r.stage !== 'Paga').reduce((s, r) => s + valOf(r), 0);
+    const vencido = records.filter((r) => r.stage === 'Vencida').reduce((s, r) => s + valOf(r), 0);
+    const emNeg = records.filter((r) => r.stage === 'Em negociação').reduce((s, r) => s + valOf(r), 0);
+    const rows = records.filter((r) =>
+      statFilter === 'aberto' ? r.stage !== 'Paga'
+      : statFilter === 'vencido' ? r.stage === 'Vencida'
+      : statFilter === 'neg' ? r.stage === 'Em negociação'
+      : true,
+    );
+    return (
+      <div className="jd-fin">
+        <div className="jd-stats">
+          <MoneyStat label="Em aberto" value={emAberto} accent="blue" active={statFilter === 'aberto'} reduced={reducedRef.current} onClick={() => statClick('aberto')} />
+          <MoneyStat label="Vencido" value={vencido} accent="red" active={statFilter === 'vencido'} reduced={reducedRef.current} onClick={() => statClick('vencido')} />
+          <MoneyStat label="Em negociação" value={emNeg} accent="amber" active={statFilter === 'neg'} reduced={reducedRef.current} onClick={() => statClick('neg')} />
+        </div>
+        <div className="jd-fin-tools">
+          {statFilter ? (
+            <button className="jd-link" onClick={() => setStatFilter(null)}>limpar filtro</button>
+          ) : (
+            <span className="jd-mini">{records.length + cen.extraN} faturas · toque num indicador para filtrar</span>
+          )}
+          <button className="jd-finadd" onClick={() => setNewOpen(true)}>{cen.newForm.add}</button>
+        </div>
+        <div className="jd-table-wrap">
+          <table className="jd-table">
+            <thead>
+              <tr><th>Cliente</th><th>Valor</th><th>Vencimento</th><th>Status</th><th></th></tr>
+            </thead>
+            <tbody>
+              {rows.map((r) => (
+                <tr key={r.id} onClick={() => openRecord(r.id)} tabIndex={0}
+                  onKeyDown={(e) => e.key === 'Enter' && openRecord(r.id)}>
+                  <td className="jd-tname">{r.name}</td>
+                  <td>{r.meta.valor}</td>
+                  <td>{r.meta.venc}</td>
+                  <td>{statusPill(r.stage)}</td>
+                  <td className="jd-tright"><span className="jd-openx">abrir →</span></td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+          {statFilter && rows.length === 0 && <div className="jd-tcount">Nenhuma fatura neste filtro.</div>}
+        </div>
+      </div>
+    );
+  }
+
+  // ---- superfície: CHATS (atendimento) ----
+  function renderFila() {
+    return (
+      <div className="jd-fila-wrap">
+        <div className="jd-rules" aria-label="Regras do atendimento">
+          <span className="jd-rule">🤖 agenda sozinho ✓</span>
+          <span className="jd-rule">🙋 clínico → humano ✓</span>
+          {evolveState === 'applied' && (
+            <span className="jd-rule jd-rule-new">{cen.evolve.regra} <b>NOVO</b></span>
+          )}
+        </div>
+        <div className="jd-fila">
+          {records.map((r) => {
+            const m = lastMsg(r);
+            const unread = m?.who === 'user';
+            return (
+              <button key={r.id} className="jd-fila-item" onClick={() => openRecord(r.id)}>
+                <span className="jd-avatar">{r.name.charAt(0)}</span>
+                <span className="jd-fila-main">
+                  <span className="jd-fila-top">
+                    <span className="jd-fila-name">{r.name}</span>
+                    {statusPill(r.stage)}
+                  </span>
+                  <span className="jd-fila-prev">{m?.who === 'agent' ? '✓ ' : ''}{m?.text}</span>
+                </span>
+                <span className="jd-fila-meta">
+                  <span className="jd-fila-time">{m?.time}</span>
+                  {unread && <span className="jd-unread" aria-label="não lida" />}
+                </span>
+              </button>
+            );
+          })}
+          <div className="jd-kmore">+{cen.extraN} conversas da planilha</div>
+          <button className="jd-finadd jd-fila-add" onClick={() => setNewOpen(true)}>{cen.newForm.add}</button>
+        </div>
+      </div>
+    );
+  }
+
+  function renderThread(rec: Registro) {
+    const nbaVisible = rec.nba && !rec.nbaDone;
+    const handoff = rec.nba?.kind === 'handoff';
+    return (
+      <div className="jd-conv">
+        <div className="jd-chat-head">
+          <span className="jd-avatar sm">{rec.name.charAt(0)}</span>
+          <b>{rec.name}</b>
+          {statusPill(rec.stage)}
+        </div>
+        <div className="jd-thread">
+          {rec.log.map((e, i) =>
+            e.who === 'system' ? (
+              <div key={i} className="jd-cb-sys">{e.text}</div>
+            ) : (
+              <div key={i} className={'jd-cb ' + e.who}>
+                <span className="jd-cb-b">{e.text}</span>
+                <time>{e.time}</time>
+              </div>
+            ),
+          )}
+          {nbaVisible && (
+            <div className={'jd-nba jd-nba-inline' + (handoff ? ' jd-nba-hand' : '')}>
+              <span className="jd-nba-k">{handoff ? '🙋 Humano assume' : '🤖 Sugestão do assistente'}</span>
+              <span>{rec.nba!.text}</span>
+              <button className="jd-btn jd-pri" onClick={() => nbaAction(rec.id)}>Fazer isso</button>
+            </div>
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  // ---- ficha (kanban/financeiro): campos + NBA + histórico ----
+  function renderFicha(rec: Registro) {
+    const nba = rec.nba ?? cen.nbaDefault(rec);
+    const nbaVisible = !rec.nbaDone;
+    return (
+      <div className="jd-record">
+        <div className="jd-rec-head">
+          <b>{rec.name}</b>
+          {statusPill(rec.stage)}
+        </div>
+        <div className="jd-rec-grid">
+          <dl className="jd-fields">
+            {cen.recordFields(rec).map((f) => (
+              <div key={f.label}>
+                <dt>{f.label}</dt>
+                <dd>
+                  {f.value}
+                  {f.lock && (
+                    <span className="jd-lock" title="Protegido: seu papel vê mascarado — decidido no desenho"> 🔒</span>
+                  )}
+                </dd>
+              </div>
+            ))}
+          </dl>
+          {nbaVisible && (
+            <div className={'jd-nba' + (nba.kind === 'handoff' ? ' jd-nba-hand' : '')}>
+              <span className="jd-nba-k">{nba.kind === 'handoff' ? '🙋 Humano assume' : '🤖 Próximo passo sugerido'}</span>
+              <span>{nba.text}</span>
+              <button className="jd-btn jd-pri" onClick={() => nbaAction(rec.id)}>Fazer isso</button>
+            </div>
+          )}
+        </div>
+        <div className="jd-tl">
+          <span className="jd-tl-t">Histórico — tudo fica registrado</span>
+          {rec.log.map((e, i) => (
+            <div key={i} className={'jd-tl-i ' + e.who}>
+              <span>{e.text}</span><time>{e.time}</time>
+            </div>
+          ))}
+        </div>
+      </div>
+    );
+  }
+
   const badge =
     draft === 'draft' ? { cls: 'jd-b-draft', t: 'rascunho — só você vê' }
     : draft === 'kept' ? { cls: 'jd-b-kept', t: 'aprovado por você' }
@@ -1183,6 +1497,9 @@ export default function JourneyDemo() {
   const cardPendente = items.some(
     (i) => i.kind === 'card' && !i.resolved && i.card !== 'cta',
   );
+
+  const listIcon = cen.surface === 'financeiro' ? '📄' : cen.surface === 'chats' ? '📥' : '▦';
+  const recIcon = cen.surface === 'chats' ? '💬' : '👤';
 
   return (
     <div className={`jd jd-pane-${pane}`} data-demo-jornada>
@@ -1295,7 +1612,7 @@ export default function JourneyDemo() {
           </div>
         </section>
 
-        {/* ---- app vivo ---- */}
+        {/* ---- app vivo (superfície por cenário) ---- */}
         <section className="jd-app" aria-label="Seu app">
           {draft === 'none' || draft === 'building' ? (
             <div className="jd-empty">
@@ -1309,118 +1626,59 @@ export default function JourneyDemo() {
                 <b>{cen.appTitle}</b>
                 {badge && <span className={'jd-badge ' + badge.cls}>{badge.t}</span>}
                 <div className="jd-views" role="group" aria-label="Modo de visualização">
-                  <button className={view === 'kanban' ? 'on' : ''} onClick={() => setView('kanban')}>▦ {cen.boardLabel}</button>
-                  <button className={view === 'table' ? 'on' : ''} onClick={() => { setView('table'); markTouched(); }}>☰ Tabela</button>
+                  {cen.surface === 'kanban' ? (
+                    <>
+                      <button className={view === 'kanban' ? 'on' : ''} onClick={() => setView('kanban')}>▦ {cen.boardLabel}</button>
+                      <button className={view === 'table' ? 'on' : ''} onClick={() => { setView('table'); markTouched(); }}>☰ Tabela</button>
+                    </>
+                  ) : (
+                    <button className={view !== 'record' ? 'on' : ''} onClick={() => setView('kanban')}>{listIcon} {cen.boardLabel}</button>
+                  )}
                   {record && (
-                    <button className={view === 'record' ? 'on' : ''} onClick={() => setView('record')}>👤 {record.name.split(' ')[0]}</button>
+                    <button className={view === 'record' ? 'on' : ''} onClick={() => setView('record')}>{recIcon} {record.name.split(' ')[0]}</button>
                   )}
                 </div>
               </header>
 
-              {view === 'kanban' && (
-                <div className="jd-kanban">
-                  {stagesK.map((s) => {
-                    const col = records.filter((l) => l.stage === s);
-                    const extra = s === entryCol ? cen.extraN : 0;
-                    return (
-                      <div key={s} className="jd-kcol">
-                        <div className="jd-khead">{s}<span>{col.length + extra}</span></div>
-                        {col.map((l) => (
-                          <div key={l.id} className="jd-kcard">
-                            <button className="jd-kname" onClick={() => openRecord(l.id)}>{l.name}</button>
-                            <div className="jd-ksub">{cen.subtitle(l)}</div>
-                            <div className="jd-kfoot">
-                              <span className={'jd-ktag' + (l.agent ? ' ag' : '')}>{l.agent ? 'assistente moveu' : l.origem}</span>
-                              <button className="jd-kmove" onClick={() => moveRecord(l.id)} aria-label={`Mover ${l.name}`}>mover →</button>
-                            </div>
-                          </div>
+              {view === 'record' && record ? (
+                cen.surface === 'chats' ? renderThread(record) : renderFicha(record)
+              ) : cen.surface === 'kanban' ? (
+                view === 'table' ? (
+                  <div className="jd-table-wrap">
+                    <input
+                      className="jd-search"
+                      placeholder="Buscar…"
+                      value={query}
+                      onChange={(e) => setQuery(e.target.value)}
+                      aria-label="Buscar registro"
+                    />
+                    <table className="jd-table">
+                      <thead>
+                        <tr>{cen.tableCols.map((c) => <th key={c.header}>{c.header}</th>)}</tr>
+                      </thead>
+                      <tbody>
+                        {filtered.map((l) => (
+                          <tr key={l.id} onClick={() => openRecord(l.id)} tabIndex={0}
+                            onKeyDown={(e) => e.key === 'Enter' && openRecord(l.id)}>
+                            {cen.tableCols.map((c) => (
+                              <td key={c.header} className={c.primary ? 'jd-tname' : undefined}>
+                                {c.stage ? statusPill(l.stage) : <>{c.get?.(l)}{c.lock && ' 🔒'}</>}
+                              </td>
+                            ))}
+                          </tr>
                         ))}
-                        {s === entryCol && (
-                          <>
-                            {extra > 0 && <div className="jd-kmore">+{extra} da planilha</div>}
-                            <button className="jd-kadd" onClick={() => setNewOpen(true)}>{cen.newForm.add}</button>
-                          </>
-                        )}
-                      </div>
-                    );
-                  })}
-                </div>
-              )}
-
-              {view === 'table' && (
-                <div className="jd-table-wrap">
-                  <input
-                    className="jd-search"
-                    placeholder="Buscar…"
-                    value={query}
-                    onChange={(e) => setQuery(e.target.value)}
-                    aria-label="Buscar registro"
-                  />
-                  <table className="jd-table">
-                    <thead>
-                      <tr>{cen.tableCols.map((c) => <th key={c.header}>{c.header}</th>)}</tr>
-                    </thead>
-                    <tbody>
-                      {filtered.map((l) => (
-                        <tr key={l.id} onClick={() => openRecord(l.id)} tabIndex={0}
-                          onKeyDown={(e) => e.key === 'Enter' && openRecord(l.id)}>
-                          {cen.tableCols.map((c) => (
-                            <td key={c.header} className={c.primary ? 'jd-tname' : undefined}>
-                              {c.stage ? (
-                                <span className="jd-stagepill">{l.stage}</span>
-                              ) : (
-                                <>{c.get?.(l)}{c.lock && ' 🔒'}</>
-                              )}
-                            </td>
-                          ))}
-                        </tr>
-                      ))}
-                    </tbody>
-                  </table>
-                  <div className="jd-tcount">{filtered.length} exibidos · {records.length + cen.extraN} no total</div>
-                </div>
-              )}
-
-              {view === 'record' && record && (() => {
-                const nba = record.nba ?? cen.nbaDefault(record);
-                const handoff = nba.kind === 'handoff';
-                return (
-                  <div className="jd-record">
-                    <div className="jd-rec-head">
-                      <b>{record.name}</b>
-                      <span className="jd-stagepill">{record.stage}</span>
-                    </div>
-                    <div className="jd-rec-grid">
-                      <dl className="jd-fields">
-                        {cen.recordFields(record).map((f) => (
-                          <div key={f.label}>
-                            <dt>{f.label}</dt>
-                            <dd>
-                              {f.value}
-                              {f.lock && (
-                                <span className="jd-lock" title="Protegido: seu papel vê mascarado — decidido no desenho"> 🔒</span>
-                              )}
-                            </dd>
-                          </div>
-                        ))}
-                      </dl>
-                      <div className={'jd-nba' + (handoff ? ' jd-nba-hand' : '')}>
-                        <span className="jd-nba-k">{handoff ? '🙋 Humano assume' : '🤖 Próximo passo sugerido'}</span>
-                        <span>{nba.text}</span>
-                        <button className="jd-btn jd-pri" onClick={() => nbaAction(record.id)}>Fazer isso</button>
-                      </div>
-                    </div>
-                    <div className="jd-tl">
-                      <span className="jd-tl-t">Histórico — tudo fica registrado</span>
-                      {record.log.map((e, i) => (
-                        <div key={i} className={'jd-tl-i ' + e.who}>
-                          <span>{e.text}</span><time>{e.time}</time>
-                        </div>
-                      ))}
-                    </div>
+                      </tbody>
+                    </table>
+                    <div className="jd-tcount">{filtered.length} exibidos · {records.length + cen.extraN} no total</div>
                   </div>
-                );
-              })()}
+                ) : (
+                  renderKanban()
+                )
+              ) : cen.surface === 'financeiro' ? (
+                renderFinanceiro()
+              ) : (
+                renderFila()
+              )}
 
               {newOpen && (
                 <NewRecordForm
@@ -1482,6 +1740,56 @@ export default function JourneyDemo() {
   );
 }
 
+function MoneyStat({
+  label,
+  value,
+  accent,
+  active,
+  reduced,
+  onClick,
+}: {
+  label: string;
+  value: number;
+  accent: 'blue' | 'red' | 'amber';
+  active: boolean;
+  reduced: boolean;
+  onClick: () => void;
+}) {
+  const [disp, setDisp] = useState(0);
+  const fromRef = useRef(0);
+  const rafRef = useRef(0);
+  useEffect(() => {
+    if (reduced) {
+      setDisp(value);
+      fromRef.current = value;
+      return;
+    }
+    const from = fromRef.current;
+    const to = value;
+    if (from === to) return;
+    const start = performance.now();
+    const dur = 700;
+    const tick = (n: number) => {
+      const p = Math.min((n - start) / dur, 1);
+      setDisp(Math.round(from + (to - from) * p));
+      if (p < 1) rafRef.current = requestAnimationFrame(tick);
+      else fromRef.current = to;
+    };
+    rafRef.current = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(rafRef.current);
+  }, [value, reduced]);
+  return (
+    <button
+      className={'jd-stat jd-stat-' + accent + (active ? ' on' : '')}
+      onClick={onClick}
+      aria-pressed={active}
+    >
+      <span className="jd-stat-v">{brl(disp)}</span>
+      <span className="jd-stat-k">{label}</span>
+    </button>
+  );
+}
+
 function NewRecordForm({
   title,
   fields,
@@ -1517,7 +1825,7 @@ function NewRecordForm({
 
 const JD_CSS = `
 .jd { --jd-bg:#1A1B1E; --jd-panel:#25262B; --jd-line:#33353B; --jd-tx:#E5E7EB; --jd-mut:#9CA3AF;
-  --jd-blue:#4DABF7; --jd-green:#34D399; --jd-amber:#FBBF24; --jd-red:#F87171;
+  --jd-blue:#4DABF7; --jd-green:#34D399; --jd-amber:#FBBF24; --jd-red:#F87171; --jd-violet:#A78BFA;
   background: var(--jd-bg); border: 1px solid var(--jd-line); border-radius: 16px;
   color: var(--jd-tx); overflow: hidden; font-size: 14.5px; }
 .jd * { box-sizing: border-box; }
@@ -1602,7 +1910,7 @@ const JD_CSS = `
 .jd-typing i{width:6px;height:6px;border-radius:99px;background:var(--jd-mut);animation:jdb 1.2s infinite}
 .jd-typing i:nth-child(2){animation-delay:.2s}.jd-typing i:nth-child(3){animation-delay:.4s}
 @keyframes jdb{0%,100%{opacity:.25}50%{opacity:1}}
-.jd-note { align-self:center; font-size:11.5px; color:var(--jd-mut); border:1px dashed var(--jd-line); border-radius:999px; padding:3px 12px; }
+.jd-note { align-self:center; font-size:11.5px; color:var(--jd-mut); border:1px dashed var(--jd-line); border-radius:999px; padding:3px 12px; text-align:center; }
 
 .jd-card { border:1px solid var(--jd-line); border-radius:14px; background:var(--jd-panel); padding:14px; display:flex; flex-direction:column; gap:10px; }
 .jd-card.jd-gate { border-color:rgba(251,191,36,.5); box-shadow:0 0 0 3px rgba(251,191,36,.08); }
@@ -1642,10 +1950,8 @@ const JD_CSS = `
 .jd-pill { border:1px dashed var(--jd-line); background:none; color:var(--jd-mut); border-radius:999px; padding:9px 14px; font-size:13px; cursor:pointer; text-align:left; }
 .jd-pill:hover { border-color:var(--jd-blue); color:var(--jd-blue); }
 .jd-pill-imp { border-style:solid; border-color:rgba(77,171,247,.4); background:rgba(77,171,247,.08); color:var(--jd-blue); }
-.jd-pill code { font-size:11px; background:rgba(255,255,255,.08); border-radius:4px; padding:1px 5px; }
-.jd-pill em { font-style:italic; opacity:.8; font-size:11.5px; }
 
-.jd-app { display:flex; flex-direction:column; min-height:0; background:#1F2024; overflow-y:auto; }
+.jd-app { display:flex; flex-direction:column; min-height:0; background:#1F2024; overflow-y:auto; position:relative; }
 .jd-empty { flex:1; display:flex; flex-direction:column; align-items:center; justify-content:center; gap:6px; color:var(--jd-mut); padding:40px 20px; text-align:center; min-height:320px; }
 .jd-empty-ic { font-size:34px; opacity:.5; }
 .jd-app-head { display:flex; align-items:center; gap:10px; padding:12px 16px; border-bottom:1px solid var(--jd-line); flex-wrap:wrap; position:sticky; top:0; background:#1F2024; z-index:2; }
@@ -1656,6 +1962,16 @@ const JD_CSS = `
 .jd-views { margin-left:auto; display:flex; gap:2px; background:#2A2B30; border-radius:8px; padding:2px; }
 .jd-views button { border:none; background:none; color:var(--jd-mut); font-size:12px; padding:5px 11px; border-radius:6px; cursor:pointer; white-space:nowrap; }
 .jd-views button.on { background:var(--jd-panel); color:var(--jd-tx); }
+
+/* status pill colorida (financeiro/chats) */
+.jd-spill { font-size:11px; border-radius:999px; padding:2px 9px; white-space:nowrap; }
+.jd-spill-blue { background:rgba(77,171,247,.15); color:var(--jd-blue); }
+.jd-spill-red { background:rgba(248,113,113,.15); color:var(--jd-red); }
+.jd-spill-amber { background:rgba(251,191,36,.15); color:var(--jd-amber); }
+.jd-spill-violet { background:rgba(167,139,250,.18); color:var(--jd-violet); }
+.jd-spill-green { background:rgba(52,211,153,.15); color:var(--jd-green); }
+
+/* kanban (leads) */
 .jd-kanban { display:flex; gap:10px; padding:14px 16px; overflow-x:auto; flex:1; align-items:flex-start; }
 .jd-kcol { min-width:168px; flex:1; background:#26272C; border-radius:10px; padding:8px; }
 .jd-khead { display:flex; justify-content:space-between; font-size:10.5px; font-weight:700; text-transform:uppercase; letter-spacing:.05em; color:var(--jd-mut); padding:2px 4px 8px; }
@@ -1672,6 +1988,26 @@ const JD_CSS = `
 .jd-kadd { width:100%; border:1px dashed var(--jd-line); background:none; color:var(--jd-mut); border-radius:8px; padding:8px; font-size:12px; cursor:pointer; }
 .jd-kadd:hover { color:var(--jd-blue); border-color:var(--jd-blue); }
 .jd-kmore { font-size:11px; color:var(--jd-mut); text-align:center; padding:6px 0; }
+
+/* financeiro (caixa) */
+.jd-fin { display:flex; flex-direction:column; min-height:0; }
+.jd-stats { display:flex; gap:10px; padding:14px 16px 6px; flex-wrap:wrap; }
+.jd-stat { flex:1; min-width:104px; text-align:left; background:var(--jd-panel); border:1px solid var(--jd-line); border-left:3px solid var(--jd-line); border-radius:10px; padding:10px 12px; cursor:pointer; display:flex; flex-direction:column; gap:3px; }
+.jd-stat:hover { background:#2C2E33; }
+.jd-stat.on { box-shadow:0 0 0 2px rgba(77,171,247,.3); }
+.jd-stat-v { font-size:17px; font-weight:700; letter-spacing:-.01em; }
+.jd-stat-k { font-size:10px; text-transform:uppercase; letter-spacing:.05em; color:var(--jd-mut); }
+.jd-stat-blue { border-left-color:var(--jd-blue); }
+.jd-stat-red { border-left-color:var(--jd-red); }
+.jd-stat-amber { border-left-color:var(--jd-amber); }
+.jd-fin-tools { display:flex; align-items:center; gap:10px; padding:4px 16px 6px; }
+.jd-finadd { margin-left:auto; border:1px dashed var(--jd-line); background:none; color:var(--jd-mut); border-radius:8px; padding:6px 11px; font-size:12px; cursor:pointer; white-space:nowrap; }
+.jd-finadd:hover { color:var(--jd-blue); border-color:var(--jd-blue); }
+.jd-tright { text-align:right; }
+.jd-openx { color:var(--jd-mut); font-size:11.5px; }
+.jd-table tbody tr:hover .jd-openx { color:var(--jd-blue); }
+
+/* tabela (leads/financeiro) */
 .jd-table-wrap { padding:14px 16px; overflow-x:auto; }
 .jd-search { width:100%; max-width:280px; margin-bottom:10px; padding:8px 12px; border-radius:8px; border:1px solid var(--jd-line); background:var(--jd-panel); color:var(--jd-tx); font:inherit; font-size:13px; }
 .jd-table { width:100%; border-collapse:collapse; font-size:13px; }
@@ -1682,6 +2018,39 @@ const JD_CSS = `
 .jd-tname { color:var(--jd-blue); font-weight:600; }
 .jd-stagepill { font-size:11px; border-radius:999px; padding:2px 9px; background:rgba(77,171,247,.12); color:var(--jd-blue); white-space:nowrap; }
 .jd-tcount { font-size:11.5px; color:var(--jd-mut); margin-top:8px; }
+
+/* chats (atendimento) */
+.jd-fila-wrap { display:flex; flex-direction:column; min-height:0; }
+.jd-rules { display:flex; gap:6px; flex-wrap:wrap; padding:10px 16px; border-bottom:1px solid var(--jd-line); background:rgba(255,255,255,.02); }
+.jd-rule { font-size:11px; border:1px solid var(--jd-line); border-radius:999px; padding:3px 9px; color:var(--jd-mut); }
+.jd-rule-new { color:var(--jd-green); border-color:rgba(52,211,153,.4); background:rgba(52,211,153,.08); }
+.jd-rule-new b { font-size:9px; letter-spacing:.06em; margin-left:2px; }
+.jd-fila { display:flex; flex-direction:column; }
+.jd-fila-item { display:flex; gap:11px; align-items:center; padding:11px 16px; border:none; border-bottom:1px solid var(--jd-line); background:none; color:inherit; font:inherit; width:100%; text-align:left; cursor:pointer; }
+.jd-fila-item:hover { background:rgba(255,255,255,.03); }
+.jd-avatar { width:38px; height:38px; min-width:38px; border-radius:99px; background:rgba(77,171,247,.15); color:var(--jd-blue); display:flex; align-items:center; justify-content:center; font-weight:700; font-size:15px; }
+.jd-avatar.sm { width:30px; height:30px; min-width:30px; font-size:13px; }
+.jd-fila-main { flex:1; min-width:0; display:flex; flex-direction:column; gap:3px; }
+.jd-fila-top { display:flex; align-items:center; gap:8px; }
+.jd-fila-name { font-weight:600; font-size:13.5px; }
+.jd-fila-prev { font-size:12px; color:var(--jd-mut); white-space:nowrap; overflow:hidden; text-overflow:ellipsis; max-width:100%; }
+.jd-fila-meta { display:flex; flex-direction:column; align-items:flex-end; gap:5px; min-width:44px; }
+.jd-fila-time { font-size:10.5px; color:var(--jd-mut); }
+.jd-unread { width:9px; height:9px; border-radius:99px; background:var(--jd-blue); box-shadow:0 0 8px 1px rgba(77,171,247,.5); }
+.jd-fila-add { margin:10px 16px; }
+.jd-conv { display:flex; flex-direction:column; min-height:0; }
+.jd-chat-head { display:flex; align-items:center; gap:10px; padding:11px 16px; border-bottom:1px solid var(--jd-line); position:sticky; top:0; background:#1F2024; }
+.jd-thread { padding:16px; display:flex; flex-direction:column; gap:9px; }
+.jd-cb { display:flex; flex-direction:column; max-width:80%; gap:2px; }
+.jd-cb.user { align-self:flex-start; align-items:flex-start; }
+.jd-cb.agent { align-self:flex-end; align-items:flex-end; }
+.jd-cb-b { padding:8px 12px; border-radius:13px; line-height:1.45; font-size:13.5px; }
+.jd-cb.user .jd-cb-b { background:#2A2B30; border:1px solid var(--jd-line); border-bottom-left-radius:4px; }
+.jd-cb.agent .jd-cb-b { background:rgba(52,211,153,.13); border:1px solid rgba(52,211,153,.3); color:#D1FAE5; border-bottom-right-radius:4px; }
+.jd-cb time { font-size:10px; color:var(--jd-mut); padding:0 4px; }
+.jd-cb-sys { align-self:center; text-align:center; max-width:90%; font-size:12px; color:var(--jd-amber); background:rgba(251,191,36,.1); border:1px solid rgba(251,191,36,.3); border-radius:10px; padding:8px 12px; line-height:1.4; }
+.jd-nba-inline { margin:6px 0 2px; }
+
 .jd-record { padding:14px 16px; overflow-y:auto; }
 .jd-rec-head { display:flex; align-items:center; gap:10px; margin-bottom:12px; font-size:16px; }
 .jd-rec-grid { display:grid; grid-template-columns:1fr 240px; gap:14px; align-items:start; }
@@ -1702,12 +2071,12 @@ const JD_CSS = `
 .jd-tl-i::before { content:''; position:absolute; left:-5px; top:12px; width:8px; height:8px; border-radius:99px; background:var(--jd-line); }
 .jd-tl-i.agent::before { background:#A78BFA; }
 .jd-tl-i.user::before { background:var(--jd-blue); }
+.jd-tl-i.system::before { background:var(--jd-amber); }
 .jd-tl-i time { margin-left:auto; font-size:11px; white-space:nowrap; }
 .jd-modal { position:absolute; inset:0; background:rgba(0,0,0,.55); display:flex; align-items:center; justify-content:center; z-index:5; border-radius:0 0 16px 0; }
 .jd-modal-card { width:min(360px, calc(100% - 32px)); background:var(--jd-panel); border:1px solid var(--jd-line); border-radius:12px; padding:18px; display:flex; flex-direction:column; gap:10px; }
 .jd-modal-card label { font-size:11px; color:var(--jd-mut); display:flex; flex-direction:column; gap:4px; }
 .jd-modal-card input { padding:8px 11px; border-radius:8px; border:1px solid var(--jd-line); background:#1F2024; color:var(--jd-tx); font:inherit; font-size:13.5px; }
-.jd-app { position:relative; }
 .jd-trust { display:flex; gap:6px; flex-wrap:wrap; padding:10px 16px; border-top:1px solid var(--jd-line); margin-top:auto; }
 .jd-trust-chip { font-size:11px; border:1px solid var(--jd-line); border-radius:999px; padding:3px 10px; color:var(--jd-mut); opacity:.6; transition:all .25s; }
 .jd-trust-chip.on { color:var(--jd-green); border-color:rgba(52,211,153,.4); background:rgba(52,211,153,.08); opacity:1; }

--- a/src/components/JourneyDemo.tsx
+++ b/src/components/JourneyDemo.tsx
@@ -660,8 +660,10 @@ export default function JourneyDemo() {
   }, []);
 
   async function ally(text: string, ms = 700) {
+    const gen = genRef.current;
     setTyping(true);
     await delay(ms);
+    if (genRef.current !== gen) return; // recomeçar/rebuild cancelou esta fala
     setTyping(false);
     push({ kind: 'msg', who: 'ally', text });
   }
@@ -696,17 +698,20 @@ export default function JourneyDemo() {
 
   async function startPlanilha(id?: CenarioId) {
     if (!beginOnce()) return;
+    const gen = genRef.current;
     const cid = id ?? cenarioRef.current; // replay usa o cenário preservado
     if (id) aplicarCenario(id);
     const c = CENARIOS[cid];
     track('jornada_start', { entry: 'planilha', cenario: cid });
     push({ kind: 'msg', who: 'user', text: `📎 ${c.xlsx}` });
     await ally(c.planilhaRead, 900);
+    if (genRef.current !== gen) return;
     push({ kind: 'card', card: 'espelho' });
   }
 
   async function startProsa(texto: string) {
     if (!beginOnce()) return;
+    const gen = genRef.current;
     const text = texto.trim();
     const id = routeCenario(text);
     aplicarCenario(id);
@@ -717,15 +722,18 @@ export default function JourneyDemo() {
       `Boa! É exatamente assim que funciona: você escreve, eu entendo e monto. Nesta demonstração eu sigo um exemplo pronto — ${c.tema} — mas o caminho é o mesmo com o SEU problema. Olha:`,
       800,
     );
+    if (genRef.current !== gen) return;
     push({ kind: 'card', card: 'espelho' });
   }
 
   async function confirmaEspelho() {
     if (!lock('espelho')) return;
+    const gen = genRef.current;
     resolveCard('espelho', 'Confirmado por você');
     earn(0); // Enquadramento
     goStage(1);
     await ally('Então deixa eu confirmar como seu negócio funciona — corrija só o que estiver errado:', 600);
+    if (genRef.current !== gen) return;
     push({ kind: 'card', card: 'enquadrar' });
   }
 
@@ -746,9 +754,11 @@ export default function JourneyDemo() {
   async function confirmaEnquadrar() {
     if (!lock('enquadrar')) return;
     const c = CENARIOS[cenarioRef.current];
+    const gen = genRef.current;
     resolveCard('enquadrar', premEditada ? c.ajusteLabel : 'Aceito como proposto');
     goStage(2);
     await ally('Desenhei seu app inteiro. Em português, não em jargão:', 650);
+    if (genRef.current !== gen) return;
     push({ kind: 'card', card: 'desenho' });
     earn(1); // Coerência
   }
@@ -787,6 +797,7 @@ export default function JourneyDemo() {
     // no mobile, mostra o app nascendo — o momento-mágico é visual
     if (isMobile()) setPane('app');
     await ally(`🎉 Seu app está de pé — em rascunho, só seu. ${c.magic} Depois me diz se é isso.`, 700);
+    if (genRef.current !== gen) return;
     push({ kind: 'card', card: 'gate' });
   }
 
@@ -794,6 +805,7 @@ export default function JourneyDemo() {
   async function ficarComEle() {
     if (!lock('ficar')) return;
     const c = CENARIOS[cenarioRef.current];
+    const gen = genRef.current;
     if (!touchedRef.current) {
       await ally(`Experimenta mexer no app primeiro — ${c.touchHint}. Decidir vendo é o combinado. 😉`, 400);
       unlock('ficar');
@@ -805,6 +817,7 @@ export default function JourneyDemo() {
     track('jornada_keep');
     goStage(5);
     await ally('Agora o assistente assume o dia a dia — e te pergunta antes do que importa. Olha ele trabalhando:', 700);
+    if (genRef.current !== gen) return;
     const am = c.autoMove;
     setRecords((p) =>
       p.map((r) =>
@@ -819,6 +832,7 @@ export default function JourneyDemo() {
       ),
     );
     await delay(900);
+    if (genRef.current !== gen) return;
     push({ kind: 'card', card: 'hitl' });
   }
 
@@ -843,6 +857,7 @@ export default function JourneyDemo() {
   async function aprovaEnvio() {
     if (!lock('hitl')) return;
     const c = CENARIOS[cenarioRef.current];
+    const gen = genRef.current;
     // deixa o momento visível: financeiro volta pra tabela (o stat cai);
     // chats abre a conversa (a bolha de confirmação aparece na thread)
     if (c.surface === 'financeiro') {
@@ -870,16 +885,19 @@ export default function JourneyDemo() {
     );
     goStage(6);
     await ally(`${c.hitl.lead} A automação segue até o fim e fica registrada. Antes de abrir pro seu time, eu provo por dentro que cada papel vê só o combinado — aí você publica:`, 800);
+    if (genRef.current !== gen) return;
     push({ kind: 'card', card: 'publicar' });
   }
 
   async function publicar() {
     if (!lock('pub')) return;
+    const gen = genRef.current;
     resolveCard('publicar', 'Publicado para o time');
     setDraft('published');
     track('jornada_publish');
     goStage(7);
     await ally('🏁 App vivo, governado e trabalhando. Daqui pra frente, evoluir é só conversar — experimenta:', 600);
+    if (genRef.current !== gen) return;
     push({ kind: 'card', card: 'evoluir' });
   }
 
@@ -887,10 +905,12 @@ export default function JourneyDemo() {
   async function aplicarEvolucao(viaChat?: string) {
     if (!lock('evo')) return;
     const c = CENARIOS[cenarioRef.current];
+    const gen = genRef.current;
     const ev = c.evolve;
     push({ kind: 'msg', who: 'user', text: viaChat ?? ev.userMsg });
     if (viaChat) await ally(ev.allyViaChat, 550);
     await delay(450);
+    if (genRef.current !== gen) return;
     if (ev.col && ev.before) {
       const col = ev.col;
       const before = ev.before;
@@ -914,6 +934,7 @@ export default function JourneyDemo() {
     }
     setEvolveState('applied');
     await ally('Aplicado ✓ — mudança simples não pede cerimônia. E tem Desfazer, porque errar não pode machucar.', 500);
+    if (genRef.current !== gen) return;
     track('jornada_done');
     push({ kind: 'card', card: 'cta' });
   }
@@ -1035,6 +1056,19 @@ export default function JourneyDemo() {
     setTrust([false, false, false, false, false]);
     setEvolveState('none');
     setNewOpen(false);
+  }
+
+  // Recomeçar: volta ao estado de entrada COMPLETO e libera a escolha de outro
+  // exemplo — sem recarregar a página. resetAll() zera stage/chat/app e destrava
+  // startedRef/beginOnce; aqui também soltamos o cenário (volta ao neutro 'leads',
+  // como no load inicial) — diferente do replay, que preserva cenarioRef. A guarda
+  // de época (genRef) já cancela qualquer fala/card em voo do cenário anterior.
+  function recomecar() {
+    if (busyRef.current) return; // não reinicia no meio de um passo do autopilot
+    track('jornada_recomecar', { cenario: cenarioRef.current });
+    cenarioRef.current = 'leads';
+    setCenarioId('leads');
+    resetAll();
   }
 
   async function voltarPasso() {
@@ -1528,6 +1562,16 @@ export default function JourneyDemo() {
             ▶
           </button>
         </div>
+        {started && (
+          <button
+            className="jd-top-restart"
+            onClick={recomecar}
+            aria-label="Reiniciar a demonstração e escolher outro exemplo"
+            title="Reiniciar a demonstração e escolher outro exemplo"
+          >
+            ↺<span className="jd-restart-lbl"> Recomeçar</span>
+          </button>
+        )}
         <span className="jd-top-phase">demonstração · produto em construção</span>
         <span className="jd-top-phase jd-top-phase-s">em construção</span>
         <a className="jd-top-cta" href="#beta" data-track="demo-top-beta">
@@ -1848,6 +1892,8 @@ const JD_CSS = `
 .jd-top-nav button:disabled { color:var(--jd-mut); opacity:.4; cursor:default; }
 .jd-top-nav-lbl { font-size:10.5px; color:var(--jd-mut); letter-spacing:.04em; padding:0 2px; }
 @media (max-width:560px){ .jd-top-nav-lbl{ display:none; } }
+.jd-top-restart { display:flex; align-items:center; gap:4px; border:1px solid var(--jd-line); background:none; color:var(--jd-tx); font:inherit; font-size:12px; font-weight:600; border-radius:999px; padding:5px 11px; cursor:pointer; white-space:nowrap; }
+.jd-top-restart:hover { background:rgba(255,255,255,.08); border-color:var(--jd-blue); color:#fff; }
 .jd-top-phase { font-size:11px; font-weight:600; letter-spacing:.05em; color:var(--jd-amber); border:1px solid rgba(251,191,36,.35); background:rgba(251,191,36,.08); border-radius:999px; padding:3px 10px; white-space:nowrap; }
 .jd-top-phase-s { display:none; }
 .jd-top-cta { font-size:12.5px; font-weight:700; color:#fff; background:var(--jd-blue); border-radius:8px; padding:7px 12px; white-space:nowrap; }
@@ -1862,6 +1908,8 @@ const JD_CSS = `
   .jd-top-phase-s{ display:inline-block; }
   .jd-top-cta{ font-size:11.5px; padding:6px 9px; }
   .jd-top-brand{ font-size:14px; }
+  .jd-restart-lbl{ display:none; } /* vira só "↺" nos tiers apertados */
+  .jd-top-restart{ padding:5px 9px; }
 }
 .jd-cta-s { display:none; }
 @media (max-width:430px){

--- a/src/components/JourneyDemo.tsx
+++ b/src/components/JourneyDemo.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState, type ReactNode } from 'react';
 import Link from 'next/link';
 import { TRUST_RULES, CTA } from '@/lib/messages';
 import { track } from '@/lib/analytics';
@@ -9,10 +9,15 @@ import { track } from '@/lib/analytics';
    A jornada interativa — o visitante CRIA um app conversando.
 
    Diferente da demo narrada da home (DemoBuilder, dois atos), aqui o
-   visitante dirige: entrega uma planilha (ou descreve em prosa), vê o
-   espelho, corrige premissas, manda montar — e recebe um RASCUNHO VIVO
-   que ele opera (kanban, tabela, ficha do lead) ANTES de decidir
-   "ficar com ele". Aprova o que vê, não uma lista técnica.
+   visitante dirige: escolhe um cenário (ou descreve em prosa), entrega
+   uma planilha de exemplo, vê o espelho, corrige premissas, manda montar
+   — e recebe um RASCUNHO VIVO que ele opera (kanban, tabela, ficha) ANTES
+   de decidir "ficar com ele". Aprova o que vê, não uma lista técnica.
+
+   São 3 cenários (leads · fluxo de caixa · atendimento). Todo o conteúdo
+   variável vive no registro CENARIOS; a mecânica é a mesma para os três.
+   O cenário ativo fica em cenarioRef (síncrona) para o replay determinístico
+   — voltar re-executa O MESMO cenário.
 
    As 5 regras da confiança (messages.ts) acendem nos momentos em que
    acontecem — a message house demonstrada, não afirmada.
@@ -34,16 +39,21 @@ const STAGES = [
 ] as const;
 
 type LogE = { who: 'user' | 'agent'; text: string; time: string };
-type Lead = {
+
+type NBA = { text: string; kind?: 'advance' | 'handoff'; log?: string };
+
+type Registro = {
   id: string;
   name: string;
-  company: string;
-  email: string;
+  meta: Record<string, string>;
   stage: string;
   origem: string;
   agent?: boolean;
   log: LogE[];
+  nba?: NBA;
 };
+
+type Seed = { id: string; name: string; meta: Record<string, string>; stage: string; nba?: NBA };
 
 type CardId =
   | 'espelho'
@@ -61,59 +71,470 @@ type Item =
   | { kind: 'build' }
   | { kind: 'card'; card: CardId; resolved?: string };
 
-const SEED: Omit<Lead, 'stage' | 'log' | 'origem'>[] = [
-  { id: 'ana', name: 'Ana Souza', company: 'TechFin', email: 'ana@techfin.com' },
-  { id: 'bruno', name: 'Bruno Lima', company: 'AgroData', email: 'bruno@agrodata.io' },
-  { id: 'carla', name: 'Carla Mendes', company: 'FinOps Lab', email: 'carla@finopslab.com' },
-  { id: 'diego', name: 'Diego Rocha', company: 'EduPlay', email: 'diego@eduplay.com' },
-  { id: 'elisa', name: 'Elisa Prado', company: 'HealthHub', email: 'elisa@healthhub.co' },
-];
+// --------- máscaras: e-mail/CPF/CNPJ protegidos por padrão (como no produto) ---------
+const maskEmail = (email: string) => email.replace(/(.{2}).+(@.+)/, '$1●●●$2');
+const maskCPF = (cpf: string) => cpf.replace(/^(\d{3})\.(\d{3})/, '●●●.●●●');
+const maskCNPJ = (cnpj: string) => cnpj.replace(/^(\d{2})\.(\d{3})\.(\d{3})/, '●●.●●●.●●●');
 
-const BUILD_STEPS = [
-  'Guardando seus dados — 12 leads, 8 criadores, 5 contratos',
-  'Protegendo quem-vê-o-quê no mesmo ato — nada nasce desprotegido',
-  'Montando sua tela de pipeline',
-  'Ligando o assistente e a automação',
-  'Conferindo tudo por dentro — cada peça bate com o desenho',
-];
-
-const DESENHO_ROWS = [
-  { icon: '🗃️', label: 'Seus dados', text: 'Leads, criadores e contratos — ligados entre si, com os 25 registros da sua planilha' },
-  { icon: '🖥️', label: 'Sua tela', text: 'Um pipeline visual por etapa — cada papel da equipe vê a sua versão' },
-  { icon: '🤖', label: 'Seu assistente', text: 'Sugere e executa o próximo passo em cada lead — e pergunta antes do que importa' },
-  { icon: '🔁', label: 'Automação', text: 'Contrato assinado → onboarding dispara sozinho' },
-  { icon: '🔌', label: 'Conexão', text: 'Gmail para enviar propostas e contratos' },
-  { icon: '🛡️', label: 'Quem vê o quê', text: 'Jurídico só vê contratos · CPF e e-mail protegidos' },
-];
-
-const mask = (email: string) => email.replace(/(.{2}).+(@.+)/, '$1●●●$2');
+// --------- **negrito** dentro de strings de conteúdo (premissas, HITL) ---------
+function boldify(text: string): ReactNode {
+  return text.split(/\*\*(.+?)\*\*/g).map((p, i) => (i % 2 === 1 ? <b key={i}>{p}</b> : p));
+}
 
 const INITIAL_ITEMS: Item[] = [
   {
     kind: 'msg',
     who: 'ally',
-    text: 'Oi! 👋 Me conta um problema do seu negócio — escreva aqui embaixo, com as suas palavras — ou me dá uma planilha, que eu leio como você trabalha hoje. Os dois caminhos valem.',
+    text: 'Oi! 👋 Escolha um exemplo aqui embaixo — ou me conta um problema do seu negócio com as suas palavras, que eu leio como você trabalha hoje. Os dois caminhos valem.',
   },
 ];
+
+// ======================= CENÁRIOS =======================
+
+type CenarioId = 'leads' | 'caixa' | 'atendimento';
+
+type Premissa =
+  | { icon: string; text: string }
+  | {
+      icon: string;
+      kind: 'edit';
+      before: string;
+      after: string;
+      userMsg: string;
+      ally: string;
+      addColuna?: string; // leads: acrescenta a coluna ao funil; demais: só texto
+    };
+
+const isEdit = (p: Premissa): p is Extract<Premissa, { kind: 'edit' }> =>
+  'kind' in p && p.kind === 'edit';
+
+type DesenhoRow = { icon: string; label: string; text: string };
+type Field = { label: string; value: string; lock?: boolean };
+type TableCol = {
+  header: string;
+  get?: (r: Registro) => string;
+  lock?: boolean;
+  stage?: boolean;
+  primary?: boolean;
+};
+
+type Cenario = {
+  id: CenarioId;
+  pill: string;
+  tema: string; // roteiro do texto livre
+  // entrada
+  xlsx: string; // "contas-a-receber.xlsx (2 abas · 22 linhas)"
+  planilhaRead: string; // fala do assistente ao ler a planilha
+  espelhoChips: string[];
+  // enquadrar
+  premissas: Premissa[];
+  ajusteLabel: string;
+  // desenho
+  desenho: DesenhoRow[];
+  // build
+  buildSteps: string[];
+  // registros
+  columns: string[];
+  extraN: number;
+  seed: Seed[];
+  autoMove: { id: string; toStage: string; log: string };
+  nbaDefault: (r: Registro) => NBA;
+  // app
+  appTitle: string;
+  boardLabel: string;
+  ctaObj: string;
+  // render dos registros
+  subtitle: (r: Registro) => string;
+  recordFields: (r: Registro) => Field[];
+  tableCols: TableCol[];
+  newForm: {
+    title: string;
+    add: string;
+    fields: { label: string; def: string }[];
+    build: (v: string[]) => { name: string; meta: Record<string, string> };
+  };
+  // magia / operar
+  magic: string; // fala depois de montar
+  touchHint: string; // pedido para mexer antes de decidir
+  // HITL
+  hitl: {
+    text: string;
+    button: string;
+    note: string;
+    lead: string; // primeira frase do assistente depois de aprovar
+    resolveLabel: string;
+    apply: { id: string; toStage: string; log: string };
+  };
+  // evoluir
+  evolve: {
+    userMsg: string;
+    col: string;
+    before: string;
+    allyViaChat: string;
+    doneLabel: string;
+  };
+};
+
+const CENARIOS: Record<CenarioId, Cenario> = {
+  // ---------------------------------------------------------------- LEADS
+  leads: {
+    id: 'leads',
+    pill: '📊 Leads e contratos — hoje é planilha',
+    tema: 'leads e contratos',
+    xlsx: 'leads-criadores.xlsx (3 abas · 25 linhas)',
+    planilhaRead:
+      'Li sua planilha. A aba "Leads" tem 12 leads (colunas viram campos) · "Criadores" tem 8 — detectei CPF e já vou proteger · "Contratos" tem 5, ligados aos criadores. Seus dados entram de verdade, sem redigitar nada.',
+    espelhoChips: ['Leads', 'Criadores', 'Contratos'],
+    premissas: [
+      { icon: '👥', text: 'Quem usa: **Recrutador · Gestor · Jurídico**' },
+      {
+        icon: '🔁',
+        kind: 'edit',
+        before: 'Funil: **Novo → Qualificado → Proposta → Contrato (4 etapas)**',
+        after: 'Funil: **Novo → Qualificado → Proposta → Contrato → Onboarding**',
+        userMsg: 'Falta a etapa de Onboarding no fim do funil.',
+        ally: 'Funil com 5 etapas ✓ — eu proponho, você corrige. É assim que funciona.',
+        addColuna: 'Onboarding',
+      },
+      { icon: '🔒', text: 'E-mail e CPF **protegidos por padrão**' },
+      { icon: '🛡️', text: 'Jurídico vê **só contratos**' },
+      { icon: '⚡', text: 'Contrato só sai **com o seu OK**' },
+    ],
+    ajusteLabel: 'Aceito, com seu ajuste no funil',
+    desenho: [
+      { icon: '🗃️', label: 'Seus dados', text: 'Leads, criadores e contratos — ligados entre si, com os 25 registros da sua planilha' },
+      { icon: '🖥️', label: 'Sua tela', text: 'Um pipeline visual por etapa — cada papel da equipe vê a sua versão' },
+      { icon: '🤖', label: 'Seu assistente', text: 'Sugere e executa o próximo passo em cada lead — e pergunta antes do que importa' },
+      { icon: '🔁', label: 'Automação', text: 'Contrato assinado → onboarding dispara sozinho' },
+      { icon: '🔌', label: 'Conexão', text: 'Gmail para enviar propostas e contratos' },
+      { icon: '🛡️', label: 'Quem vê o quê', text: 'Jurídico só vê contratos · CPF e e-mail protegidos' },
+    ],
+    buildSteps: [
+      'Guardando seus dados — 12 leads, 8 criadores, 5 contratos',
+      'Protegendo quem-vê-o-quê no mesmo ato — nada nasce desprotegido',
+      'Montando sua tela de pipeline',
+      'Ligando o assistente e a automação',
+      'Conferindo tudo por dentro — cada peça bate com o desenho',
+    ],
+    columns: ['Novo', 'Qualificado', 'Proposta', 'Contrato'],
+    extraN: 7,
+    seed: [
+      { id: 'ana', name: 'Ana Souza', stage: 'Novo', meta: { empresa: 'TechFin', email: 'ana@techfin.com' } },
+      { id: 'bruno', name: 'Bruno Lima', stage: 'Novo', meta: { empresa: 'AgroData', email: 'bruno@agrodata.io' } },
+      { id: 'carla', name: 'Carla Mendes', stage: 'Novo', meta: { empresa: 'FinOps Lab', email: 'carla@finopslab.com' } },
+      { id: 'diego', name: 'Diego Rocha', stage: 'Novo', meta: { empresa: 'EduPlay', email: 'diego@eduplay.com' } },
+      { id: 'elisa', name: 'Elisa Prado', stage: 'Novo', meta: { empresa: 'HealthHub', email: 'elisa@healthhub.co' } },
+    ],
+    autoMove: { id: 'bruno', toStage: 'Qualificado', log: 'Assistente qualificou — próximo passo sugerido' },
+    nbaDefault: (r) => ({
+      text:
+        r.stage === 'Novo'
+          ? 'Qualificar este lead — os dados vieram completos.'
+          : r.stage === 'Contrato'
+            ? 'Acompanhar a assinatura — contrato enviado.'
+            : 'Avançar para a próxima etapa do funil.',
+    }),
+    appTitle: 'Pipeline de Leads',
+    boardLabel: 'Pipeline',
+    ctaObj: 'um app',
+    subtitle: (r) => `${r.meta.empresa} · ${maskEmail(r.meta.email)}`,
+    recordFields: (r) => [
+      { label: 'Nome', value: r.name },
+      { label: 'Empresa', value: r.meta.empresa },
+      { label: 'E-mail', value: maskEmail(r.meta.email), lock: true },
+      { label: 'Etapa', value: r.stage },
+      { label: 'Dono', value: 'Recrutador (você)' },
+    ],
+    tableCols: [
+      { header: 'Nome', get: (r) => r.name, primary: true },
+      { header: 'Empresa', get: (r) => r.meta.empresa },
+      { header: 'E-mail', get: (r) => maskEmail(r.meta.email), lock: true },
+      { header: 'Etapa', stage: true },
+    ],
+    newForm: {
+      title: 'Novo lead',
+      add: '+ Novo lead',
+      fields: [
+        { label: 'Nome', def: 'Gustavo Reis' },
+        { label: 'Empresa', def: 'RetailPro' },
+        { label: 'E-mail', def: 'gustavo@retailpro.com' },
+      ],
+      build: (v) => ({
+        name: v[0] || 'Gustavo Reis',
+        meta: { empresa: v[1] || 'RetailPro', email: v[2] || 'gustavo@retailpro.com' },
+      }),
+    },
+    magic:
+      'Os leads da planilha já estão na tela. Mexe à vontade: clique num nome, crie um lead, mova um card.',
+    touchHint: 'cria ou move um lead, abre uma ficha',
+    hitl: {
+      text: 'O contrato da **Ana Souza (TechFin)** está pronto. Envio por Gmail?',
+      button: 'Aprovar envio',
+      note: 'Você aprovou: contrato para Ana Souza',
+      lead: 'Contrato foi.',
+      resolveLabel: 'Você aprovou o envio',
+      apply: { id: 'ana', toStage: 'Contrato', log: 'Contrato enviado por Gmail — aprovado por você' },
+    },
+    evolve: {
+      userMsg: 'Adiciona a etapa Negociação antes de Contrato.',
+      col: 'Negociação',
+      before: 'Contrato',
+      allyViaChat:
+        'É assim que se evolui — pedindo. Nesta demonstração eu aplico um exemplo pronto: a etapa Negociação antes de Contrato. Olha o pipeline:',
+      doneLabel: 'etapa Negociação no pipeline',
+    },
+  },
+
+  // ---------------------------------------------------------------- CAIXA
+  caixa: {
+    id: 'caixa',
+    pill: '💰 Contas a receber e cobrança — hoje é planilha',
+    tema: 'contas a receber e cobrança',
+    xlsx: 'contas-a-receber.xlsx (2 abas · 22 linhas)',
+    planilhaRead:
+      'Li sua planilha. A aba "Faturas" tem 14 faturas (colunas viram campos: cliente, valor, vencimento) · "Clientes" tem 8 — detectei CNPJ e já vou proteger. Entendi: acompanhar faturas a receber, vencimentos e a régua de cobrança — hoje numa planilha. Seus dados entram de verdade, sem redigitar nada.',
+    espelhoChips: ['Faturas', 'Clientes', 'Cobranças'],
+    premissas: [
+      {
+        icon: '🔔',
+        kind: 'edit',
+        before: 'Régua de cobrança em **3 toques** (lembrete → cobrança → proposta de acordo)',
+        after: 'Régua de cobrança em **4 toques** (aviso amigável → lembrete → cobrança → proposta de acordo)',
+        userMsg: 'Antes da cobrança tem um aviso amigável — minha régua tem 4 toques.',
+        ally: 'Régua com 4 toques ✓ — eu proponho, você corrige.',
+      },
+      { icon: '✋', text: 'Desconto acima de **5% só com sua aprovação** (decisão humana)' },
+      { icon: '👁️', text: 'Valores visíveis **só para o papel Financeiro**' },
+      { icon: '🔒', text: 'CNPJ e e-mail **protegidos por padrão**' },
+    ],
+    ajusteLabel: 'Aceito, com seu ajuste na régua',
+    desenho: [
+      { icon: '🗃️', label: 'Seus dados', text: 'Faturas, clientes e cobranças ligados, com os 22 registros da planilha' },
+      { icon: '🖥️', label: 'Sua tela', text: 'Painel de recebíveis por status, com o total em risco no topo' },
+      { icon: '🤖', label: 'Seu assistente', text: 'Prioriza quem cobrar, redige a mensagem — e pergunta antes de enviar' },
+      { icon: '🔁', label: 'Automação', text: 'Vencimento chegou → a régua dispara sozinha' },
+      { icon: '🔌', label: 'Conexão', text: 'Gmail e WhatsApp para lembretes e cobranças' },
+      { icon: '🛡️', label: 'Quem vê o quê', text: 'Valores só para o Financeiro · CNPJ protegido' },
+    ],
+    buildSteps: [
+      'Guardando seus dados — 14 faturas, 8 clientes, cobranças',
+      'Protegendo CNPJ e valores no mesmo ato — nada nasce desprotegido',
+      'Montando sua tela de recebíveis',
+      'Ligando o assistente e a régua de cobrança',
+      'Conferindo tudo por dentro — cada peça bate com o desenho',
+    ],
+    columns: ['A vencer', 'Vencida', 'Em negociação', 'Paga'],
+    extraN: 9,
+    seed: [
+      {
+        id: 'techfin',
+        name: 'TechFin',
+        stage: 'A vencer',
+        meta: { valor: 'R$ 12.400', venc: 'vence amanhã', email: 'financeiro@techfin.com', cnpj: '11.222.333/0001-81' },
+        nba: { text: 'Lembrete amigável — a fatura vence amanhã.' },
+      },
+      { id: 'agro', name: 'AgroData', stage: 'Vencida', meta: { valor: 'R$ 8.900', venc: 'vencida há 12 dias', email: 'financeiro@agrodata.io', cnpj: '44.555.666/0001-72' } },
+      { id: 'finops', name: 'FinOps Lab', stage: 'Em negociação', meta: { valor: 'R$ 21.000', venc: 'em negociação', email: 'contas@finopslab.com', cnpj: '77.888.999/0001-63' } },
+      { id: 'eduplay', name: 'EduPlay', stage: 'A vencer', meta: { valor: 'R$ 5.600', venc: 'vence em 6 dias', email: 'financeiro@eduplay.com', cnpj: '22.333.444/0001-54' } },
+      { id: 'healthhub', name: 'HealthHub', stage: 'Vencida', meta: { valor: 'R$ 3.100', venc: 'vencida há 3 dias', email: 'financeiro@healthhub.co', cnpj: '55.666.777/0001-45' } },
+    ],
+    autoMove: { id: 'healthhub', toStage: 'Em negociação', log: 'Assistente priorizou a cobrança — próximo passo sugerido' },
+    nbaDefault: () => ({ text: 'Enviar o próximo toque da régua — acompanhar o vencimento.' }),
+    appTitle: 'Contas a Receber',
+    boardLabel: 'Recebíveis',
+    ctaObj: 'uma cobrança',
+    subtitle: (r) => `${r.meta.valor} · ${r.meta.venc}`,
+    recordFields: (r) => [
+      { label: 'Cliente', value: r.name },
+      { label: 'Valor', value: r.meta.valor },
+      { label: 'Vencimento', value: r.meta.venc },
+      { label: 'CNPJ', value: maskCNPJ(r.meta.cnpj), lock: true },
+      { label: 'E-mail', value: maskEmail(r.meta.email), lock: true },
+      { label: 'Status', value: r.stage },
+      { label: 'Dono', value: 'Financeiro (você)' },
+    ],
+    tableCols: [
+      { header: 'Cliente', get: (r) => r.name, primary: true },
+      { header: 'Valor', get: (r) => r.meta.valor },
+      { header: 'CNPJ', get: (r) => maskCNPJ(r.meta.cnpj), lock: true },
+      { header: 'Status', stage: true },
+    ],
+    newForm: {
+      title: 'Nova fatura',
+      add: '+ Nova fatura',
+      fields: [
+        { label: 'Cliente', def: 'Contoso' },
+        { label: 'Valor', def: 'R$ 4.200' },
+        { label: 'Vencimento', def: 'vence em 15 dias' },
+      ],
+      build: (v) => ({
+        name: v[0] || 'Contoso',
+        meta: {
+          valor: v[1] || 'R$ 4.200',
+          venc: v[2] || 'vence em 15 dias',
+          email: 'financeiro@contoso.com',
+          cnpj: '99.888.777/0001-66',
+        },
+      }),
+    },
+    magic:
+      'As faturas da planilha já estão na tela. Mexe à vontade: clique num cliente, crie uma fatura, mova um card.',
+    touchHint: 'move uma fatura, abre uma ficha',
+    hitl: {
+      text: 'A fatura da **AgroData (R$ 8.900)** está 12 dias vencida. Preparei a cobrança com proposta de parcelamento em 2x — envio?',
+      button: 'Aprovar envio',
+      note: 'Você aprovou: cobrança para AgroData',
+      lead: 'Cobrança enviada.',
+      resolveLabel: 'Você aprovou o envio',
+      apply: { id: 'agro', toStage: 'Em negociação', log: 'Cobrança enviada com proposta de parcelamento — aprovada por você' },
+    },
+    evolve: {
+      userMsg: 'Adiciona a etapa Acordo antes de Paga.',
+      col: 'Acordo',
+      before: 'Paga',
+      allyViaChat:
+        'É assim que se evolui — pedindo. Nesta demonstração eu aplico um exemplo pronto: a etapa Acordo antes de Paga. Olha o quadro:',
+      doneLabel: 'etapa Acordo no quadro',
+    },
+  },
+
+  // ---------------------------------------------------------------- ATENDIMENTO
+  atendimento: {
+    id: 'atendimento',
+    pill: '📅 Atendimento no WhatsApp que resolve — agenda lotada de mensagens',
+    tema: 'atendimento no WhatsApp',
+    xlsx: 'pacientes.xlsx (2 abas · 20 linhas)',
+    planilhaRead:
+      'Li sua planilha. A aba "Pacientes" tem 15 pacientes (colunas viram campos) · "Convênios" tem 5 — detectei CPF e já vou proteger. Entendi: atender no WhatsApp, agendar e remarcar consultas e confirmar presença — hoje uma pessoa responde tudo, o dia inteiro. Seus dados entram de verdade, sem redigitar nada.',
+    espelhoChips: ['Pacientes', 'Agenda', 'Conversas'],
+    premissas: [
+      {
+        icon: '🕒',
+        kind: 'edit',
+        before: 'Atendimento **seg–sex, 8h–18h**',
+        after: 'Atendimento **seg–sex 8h–18h + sábado até 12h**',
+        userMsg: 'Sábado de manhã também temos agenda.',
+        ally: 'Sábado até 12h ✓ — anotado.',
+      },
+      { icon: '🤖', text: 'O assistente **agenda, remarca e confirma sozinho**' },
+      { icon: '🚨', text: 'Assunto clínico ou urgência → **uma pessoa assume na hora**' },
+      { icon: '🔒', text: 'Dado de saúde **nunca circula no chat**' },
+    ],
+    ajusteLabel: 'Aceito, com seu ajuste no horário',
+    desenho: [
+      { icon: '🗃️', label: 'Seus dados', text: 'Pacientes, agenda e conversas ligados, com os 20 registros da planilha' },
+      { icon: '🖥️', label: 'Sua tela', text: 'Fila de conversas por status, com a agenda do dia ao lado' },
+      { icon: '🤖', label: 'Seu assistente', text: 'Atende e executa: agenda, remarca, confirma — não é um chat que só responde' },
+      { icon: '🔁', label: 'Automação', text: 'Consulta marcada → confirmação automática na véspera' },
+      { icon: '🔌', label: 'Conexão', text: 'WhatsApp e agenda (Google Calendar)' },
+      { icon: '🛡️', label: 'Quem vê o quê', text: 'Assunto clínico só para a equipe · CPF protegido' },
+    ],
+    buildSteps: [
+      'Guardando seus dados — 15 pacientes, agenda, conversas',
+      'Protegendo CPF e dados de saúde no mesmo ato — nada nasce desprotegido',
+      'Montando sua tela de atendimento',
+      'Ligando o assistente e as confirmações automáticas',
+      'Conferindo tudo por dentro — cada peça bate com o desenho',
+    ],
+    columns: ['Novo', 'Em atendimento', 'Aguardando paciente', 'Resolvido'],
+    extraN: 8,
+    seed: [
+      { id: 'marina', name: 'Marina Lopes', stage: 'Novo', meta: { pedido: 'quer remarcar para quinta', cpf: '123.456.789-01' } },
+      { id: 'jose', name: 'José Neto', stage: 'Novo', meta: { pedido: 'primeira consulta, pediu horário', cpf: '234.567.890-12' } },
+      {
+        id: 'paula',
+        name: 'Paula Reis',
+        stage: 'Em atendimento',
+        meta: { pedido: 'perguntou sobre resultado de exame', cpf: '345.678.901-23' },
+        nba: {
+          text: 'Assunto clínico detectado — não respondo isso: passo para a equipe agora.',
+          kind: 'handoff',
+          log: 'Encaminhado para humano — assunto clínico nunca fica com o assistente',
+        },
+      },
+      { id: 'carlos', name: 'Carlos Dias', stage: 'Aguardando paciente', meta: { pedido: 'confirmar presença amanhã', cpf: '456.789.012-34' } },
+      { id: 'rita', name: 'Rita Souza', stage: 'Novo', meta: { pedido: 'dúvida de convênio', cpf: '567.890.123-45' } },
+    ],
+    autoMove: { id: 'rita', toStage: 'Em atendimento', log: 'Assistente respondeu a dúvida de convênio — próximo passo sugerido' },
+    nbaDefault: () => ({ text: 'Responder e agendar — o assistente resolve e confirma.' }),
+    appTitle: 'Atendimento — WhatsApp',
+    boardLabel: 'Conversas',
+    ctaObj: 'um atendimento',
+    subtitle: (r) => r.meta.pedido,
+    recordFields: (r) => [
+      { label: 'Paciente', value: r.name },
+      { label: 'Pedido', value: r.meta.pedido },
+      { label: 'CPF', value: maskCPF(r.meta.cpf), lock: true },
+      { label: 'Status', value: r.stage },
+      { label: 'Dono', value: 'Atendente (você)' },
+    ],
+    tableCols: [
+      { header: 'Paciente', get: (r) => r.name, primary: true },
+      { header: 'Pedido', get: (r) => r.meta.pedido },
+      { header: 'CPF', get: (r) => maskCPF(r.meta.cpf), lock: true },
+      { header: 'Status', stage: true },
+    ],
+    newForm: {
+      title: 'Nova conversa',
+      add: '+ Nova conversa',
+      fields: [
+        { label: 'Paciente', def: 'Lucas Alves' },
+        { label: 'Pedido', def: 'quer marcar avaliação' },
+        { label: 'CPF', def: '678.901.234-56' },
+      ],
+      build: (v) => ({
+        name: v[0] || 'Lucas Alves',
+        meta: { pedido: v[1] || 'quer marcar avaliação', cpf: v[2] || '678.901.234-56' },
+      }),
+    },
+    magic:
+      'As conversas da planilha já estão na tela. Mexe à vontade: clique num nome, abra uma conversa, mova um card.',
+    touchHint: 'move uma conversa, abre uma ficha',
+    hitl: {
+      text: 'O **José pediu primeira consulta amanhã às 10h** — a agenda está livre. Confirmo o agendamento?',
+      button: 'Confirmar agendamento',
+      note: 'Você aprovou: consulta do José confirmada',
+      lead: 'Consulta confirmada.',
+      resolveLabel: 'Você confirmou o agendamento',
+      apply: { id: 'jose', toStage: 'Aguardando paciente', log: 'Consulta confirmada e agendada — aprovada por você' },
+    },
+    evolve: {
+      userMsg: 'Adiciona a coluna Confirmação antes de Resolvido.',
+      col: 'Confirmação',
+      before: 'Resolvido',
+      allyViaChat:
+        'É assim que se evolui — pedindo. Nesta demonstração eu aplico um exemplo pronto: a coluna Confirmação antes de Resolvido. Olha o quadro:',
+      doneLabel: 'coluna Confirmação no quadro',
+    },
+  },
+};
+
+const CENARIO_IDS = Object.keys(CENARIOS) as CenarioId[];
+
+function routeCenario(text: string): CenarioId {
+  const t = text.toLowerCase();
+  if (/fatur|cobran|caixa|receb|boleto|inadimpl/.test(t)) return 'caixa';
+  if (/atend|agend|consult|whatsapp|paciente|marcar/.test(t)) return 'atendimento';
+  return 'leads';
+}
 
 export default function JourneyDemo() {
   const [items, setItems] = useState<Item[]>(INITIAL_ITEMS);
   const [stage, setStage] = useState(0);
   const [typing, setTyping] = useState(false);
   const [started, setStarted] = useState(false);
-  const [funilEditado, setFunilEditado] = useState(false);
+  const [cenarioId, setCenarioId] = useState<CenarioId>('leads');
+  const [premEditada, setPremEditada] = useState(false);
   const [buildDone, setBuildDone] = useState(0);
-  const [stagesK, setStagesK] = useState<string[]>([
-    'Novo', 'Qualificado', 'Proposta', 'Contrato',
-  ]);
-  const [leads, setLeads] = useState<Lead[]>([]);
+  const [stagesK, setStagesK] = useState<string[]>(CENARIOS.leads.columns);
+  const [records, setRecords] = useState<Registro[]>([]);
   const [view, setView] = useState<'kanban' | 'table' | 'record'>('kanban');
   const [recordId, setRecordId] = useState<string | null>(null);
   const [query, setQuery] = useState('');
   const [draft, setDraft] = useState<'none' | 'building' | 'draft' | 'kept' | 'published'>('none');
   const [trust, setTrust] = useState<boolean[]>([false, false, false, false, false]);
-  const [negociacao, setNegociacao] = useState<'none' | 'applied' | 'undone'>('none');
-  const [newLeadOpen, setNewLeadOpen] = useState(false);
+  const [evolveState, setEvolveState] = useState<'none' | 'applied' | 'undone'>('none');
+  const [newOpen, setNewOpen] = useState(false);
   const [chatText, setChatText] = useState('');
   // mobile: um painel por vez (chat ⇄ app), padrão do protótipo DP087
   const [pane, setPane] = useState<'chat' | 'app'>('chat');
@@ -124,6 +545,9 @@ export default function JourneyDemo() {
   const reducedRef = useRef(false);
   const scrollRef = useRef<HTMLDivElement>(null);
   const touchedRef = useRef(false);
+  // cenário ativo, síncrono — sobrevive ao resetAll do replay (voltar re-executa
+  // O MESMO cenário). Só muda antes de started (pill) ou via roteamento do texto livre.
+  const cenarioRef = useRef<CenarioId>('leads');
   // trava síncrona de início: 2 cliques no mesmo tick (ou 1 em cada pill de
   // entrada) não podem disparar jornadas paralelas — estado React é assíncrono
   const startedRef = useRef(false);
@@ -178,7 +602,7 @@ export default function JourneyDemo() {
 
   const goStage = (n: number) => {
     setStage(n);
-    track('jornada_stage', { stage: n, label: STAGES[n] });
+    track('jornada_stage', { stage: n, label: STAGES[n], cenario: cenarioRef.current });
   };
 
   const isMobile = () =>
@@ -195,39 +619,36 @@ export default function JourneyDemo() {
   };
 
   // ---------------- E0: entrada ----------------
-  async function startPlanilha() {
+  // Aplica o cenário escolhido (pill ou roteamento) — antes de começar.
+  const aplicarCenario = (id: CenarioId) => {
+    cenarioRef.current = id;
+    setCenarioId(id);
+    setStagesK(CENARIOS[id].columns);
+  };
+
+  async function startPlanilha(id?: CenarioId) {
     if (!beginOnce()) return;
-    track('jornada_start', { entry: 'planilha' });
-    push({ kind: 'msg', who: 'user', text: '📎 leads-criadores.xlsx (3 abas · 25 linhas)' });
-    await ally(
-      'Li sua planilha. A aba "Leads" tem 12 leads (colunas viram campos) · "Criadores" tem 8 — detectei CPF e já vou proteger · "Contratos" tem 5, ligados aos criadores. Seus dados entram de verdade, sem redigitar nada.',
-      900,
-    );
+    const cid = id ?? cenarioRef.current; // replay usa o cenário preservado
+    if (id) aplicarCenario(id);
+    const c = CENARIOS[cid];
+    track('jornada_start', { entry: 'planilha', cenario: cid });
+    push({ kind: 'msg', who: 'user', text: `📎 ${c.xlsx}` });
+    await ally(c.planilhaRead, 900);
     push({ kind: 'card', card: 'espelho' });
   }
 
-  async function startProsa(texto?: string) {
+  async function startProsa(texto: string) {
     if (!beginOnce()) return;
-    const livre = typeof texto === 'string' && texto.trim().length > 0;
-    track('jornada_start', { entry: livre ? 'prosa-livre' : 'prosa' });
-    push({
-      kind: 'msg',
-      who: 'user',
-      text: livre
-        ? texto!.trim()
-        : 'Preciso gerir leads de criadores e contratos — hoje é tudo numa planilha.',
-    });
-    if (livre) {
-      await ally(
-        'Boa! É exatamente assim que funciona: você escreve, eu entendo e monto. Nesta demonstração eu sigo um exemplo pronto — leads e contratos — mas o caminho é o mesmo com o SEU problema. Olha:',
-        800,
-      );
-    } else {
-      await ally(
-        'Entendi: captar leads de criadores, movê-los num pipeline até o contrato e acompanhar o onboarding. (Se tiver uma planilha disso, eu importo seus dados — mas não precisa.)',
-        800,
-      );
-    }
+    const text = texto.trim();
+    const id = routeCenario(text);
+    aplicarCenario(id);
+    const c = CENARIOS[id];
+    track('jornada_start', { entry: 'prosa-livre', cenario: id });
+    push({ kind: 'msg', who: 'user', text });
+    await ally(
+      `Boa! É exatamente assim que funciona: você escreve, eu entendo e monto. Nesta demonstração eu sigo um exemplo pronto — ${c.tema} — mas o caminho é o mesmo com o SEU problema. Olha:`,
+      800,
+    );
     push({ kind: 'card', card: 'espelho' });
   }
 
@@ -240,17 +661,24 @@ export default function JourneyDemo() {
     push({ kind: 'card', card: 'enquadrar' });
   }
 
-  async function editaFunil() {
-    if (!lock('funil')) return;
-    setFunilEditado(true);
-    setStagesK((p) => (p.includes('Onboarding') ? p : [...p, 'Onboarding']));
-    push({ kind: 'msg', who: 'user', text: 'Falta a etapa de Onboarding no fim do funil.' });
-    await ally('Funil com 5 etapas ✓ — eu proponho, você corrige. É assim que funciona.', 450);
+  async function corrigirPremissa() {
+    if (!lock('prem')) return;
+    const c = CENARIOS[cenarioRef.current];
+    const ep = c.premissas.find(isEdit);
+    if (!ep) return;
+    setPremEditada(true);
+    if (ep.addColuna) {
+      const col = ep.addColuna;
+      setStagesK((p) => (p.includes(col) ? p : [...p, col]));
+    }
+    push({ kind: 'msg', who: 'user', text: ep.userMsg });
+    await ally(ep.ally, 450);
   }
 
   async function confirmaEnquadrar() {
     if (!lock('enquadrar')) return;
-    resolveCard('enquadrar', funilEditado ? 'Aceito, com seu ajuste no funil' : 'Aceito como proposto');
+    const c = CENARIOS[cenarioRef.current];
+    resolveCard('enquadrar', premEditada ? c.ajusteLabel : 'Aceito como proposto');
     goStage(2);
     await ally('Desenhei seu app inteiro. Em português, não em jargão:', 650);
     push({ kind: 'card', card: 'desenho' });
@@ -260,40 +688,40 @@ export default function JourneyDemo() {
   // ---------------- E3: rascunho vivo ----------------
   async function montaRascunho() {
     if (!lock('monta')) return;
+    const c = CENARIOS[cenarioRef.current];
     resolveCard('desenho', 'Você mandou montar');
     goStage(3);
     setDraft('building');
     push({ kind: 'build' });
     const gen = ++genRef.current;
-    for (let i = 1; i <= BUILD_STEPS.length; i++) {
+    for (let i = 1; i <= c.buildSteps.length; i++) {
       await delay(520);
       if (genRef.current !== gen) return;
       setBuildDone(i);
     }
-    const seeded: Lead[] = SEED.map((l) => ({
-      ...l,
-      stage: 'Novo',
+    const arquivo = c.xlsx.split(' ')[0];
+    const seeded: Registro[] = c.seed.map((s) => ({
+      ...s,
       origem: 'da sua planilha',
-      log: [{ who: 'user', text: 'Importado da planilha leads-criadores.xlsx', time: '14:31' }],
+      agent: false,
+      log: [{ who: 'user', text: `Importado da planilha ${arquivo}`, time: '14:31' }],
     }));
-    setLeads(seeded);
+    setRecords(seeded);
     setDraft('draft');
     earn(4); // Seus dados, só seus
     goStage(4);
     // no mobile, mostra o app nascendo — o momento-mágico é visual
     if (isMobile()) setPane('app');
-    await ally(
-      '🎉 Seu app está de pé — em rascunho, só seu. Os leads da planilha já estão na tela. Mexe à vontade: clique num nome, crie um lead, mova um card. Depois me diz se é isso.',
-      700,
-    );
+    await ally(`🎉 Seu app está de pé — em rascunho, só seu. ${c.magic} Depois me diz se é isso.`, 700);
     push({ kind: 'card', card: 'gate' });
   }
 
   // ---------------- E4: aprova o que vê ----------------
   async function ficarComEle() {
     if (!lock('ficar')) return;
+    const c = CENARIOS[cenarioRef.current];
     if (!touchedRef.current) {
-      await ally('Experimenta mexer no app primeiro — cria ou move um lead, abre uma ficha. Decidir vendo é o combinado. 😉', 400);
+      await ally(`Experimenta mexer no app primeiro — ${c.touchHint}. Decidir vendo é o combinado. 😉`, 400);
       unlock('ficar');
       return;
     }
@@ -303,16 +731,17 @@ export default function JourneyDemo() {
     track('jornada_keep');
     goStage(5);
     await ally('Agora o assistente assume o dia a dia — e te pergunta antes do que importa. Olha ele trabalhando:', 700);
-    setLeads((p) =>
-      p.map((l) =>
-        l.id === 'bruno'
+    const am = c.autoMove;
+    setRecords((p) =>
+      p.map((r) =>
+        r.id === am.id
           ? {
-              ...l,
-              stage: 'Qualificado',
+              ...r,
+              stage: am.toStage,
               agent: true,
-              log: [...l.log, { who: 'agent', text: 'Assistente qualificou — próximo passo sugerido', time: now() }],
+              log: [...r.log, { who: 'agent', text: am.log, time: now() }],
             }
-          : l,
+          : r,
       ),
     );
     await delay(900);
@@ -321,11 +750,13 @@ export default function JourneyDemo() {
 
   async function ajustar() {
     if (!lock('ajustar')) return;
-    push({ kind: 'msg', who: 'user', text: 'Queria a coluna de Proposta logo depois de Novo.' });
+    const c = CENARIOS[cenarioRef.current];
+    const alvo = c.columns[2]; // 3ª coluna do funil — reordenada para logo depois da 1ª
+    push({ kind: 'msg', who: 'user', text: `Queria a coluna de ${alvo} logo depois de ${c.columns[0]}.` });
     await ally('Troquei — olha a tela. Ajustar rascunho é conversa, não retrabalho. É isso?', 500);
     setStagesK((p) => {
-      const rest = p.filter((s) => s !== 'Proposta');
-      return [rest[0], 'Proposta', ...rest.slice(1)];
+      const rest = p.filter((s) => s !== alvo);
+      return [rest[0], alvo, ...rest.slice(1)];
     });
     markTouched();
   }
@@ -337,24 +768,26 @@ export default function JourneyDemo() {
   // ---------------- E5: operar sob aprovação ----------------
   async function aprovaEnvio() {
     if (!lock('hitl')) return;
-    resolveCard('hitl', 'Você aprovou o envio');
+    const c = CENARIOS[cenarioRef.current];
+    resolveCard('hitl', c.hitl.resolveLabel);
     earn(3); // Humano assume
     track('jornada_hitl_ok');
-    push({ kind: 'note', text: `Você aprovou: contrato para Ana Souza · ${now()}` });
-    setLeads((p) =>
-      p.map((l) =>
-        l.id === 'ana'
+    push({ kind: 'note', text: `${c.hitl.note} · ${now()}` });
+    const ap = c.hitl.apply;
+    setRecords((p) =>
+      p.map((r) =>
+        r.id === ap.id
           ? {
-              ...l,
-              stage: 'Contrato',
+              ...r,
+              stage: ap.toStage,
               agent: true,
-              log: [...l.log, { who: 'agent', text: 'Contrato enviado por Gmail — aprovado por você', time: now() }],
+              log: [...r.log, { who: 'agent', text: ap.log, time: now() }],
             }
-          : l,
+          : r,
       ),
     );
     goStage(6);
-    await ally('Contrato foi. A automação segue até o fim e fica registrada. Antes de abrir pro seu time, eu provo por dentro que cada papel vê só o combinado — aí você publica:', 800);
+    await ally(`${c.hitl.lead} A automação segue até o fim e fica registrada. Antes de abrir pro seu time, eu provo por dentro que cada papel vê só o combinado — aí você publica:`, 800);
     push({ kind: 'card', card: 'publicar' });
   }
 
@@ -369,36 +802,29 @@ export default function JourneyDemo() {
   }
 
   // ---------------- E7: evoluir ----------------
-  async function addNegociacao(viaChat?: string) {
-    if (!lock('neg')) return;
-    push({
-      kind: 'msg',
-      who: 'user',
-      text: viaChat ?? 'Adiciona a etapa Negociação antes de Contrato.',
-    });
-    if (viaChat) {
-      await ally(
-        'É assim que se evolui — pedindo. Nesta demonstração eu aplico um exemplo pronto: a etapa Negociação antes de Contrato. Olha o pipeline:',
-        550,
-      );
-    }
+  async function aplicarEvolucao(viaChat?: string) {
+    if (!lock('evo')) return;
+    const c = CENARIOS[cenarioRef.current];
+    push({ kind: 'msg', who: 'user', text: viaChat ?? c.evolve.userMsg });
+    if (viaChat) await ally(c.evolve.allyViaChat, 550);
     await delay(450);
     setStagesK((p) => {
-      if (p.includes('Negociação')) return p;
-      const i = p.indexOf('Contrato');
+      if (p.includes(c.evolve.col)) return p;
+      const i = p.indexOf(c.evolve.before);
       const cp = [...p];
-      cp.splice(i, 0, 'Negociação');
+      cp.splice(i, 0, c.evolve.col);
       return cp;
     });
-    setNegociacao('applied');
+    setEvolveState('applied');
     await ally('Aplicado ✓ — mudança simples não pede cerimônia. E tem Desfazer, porque errar não pode machucar.', 500);
     track('jornada_done');
     push({ kind: 'card', card: 'cta' });
   }
 
   function desfazer() {
-    setStagesK((p) => p.filter((s) => s !== 'Negociação'));
-    setNegociacao('undone');
+    const c = CENARIOS[cenarioRef.current];
+    setStagesK((p) => p.filter((s) => s !== c.evolve.col));
+    setEvolveState('undone');
     earn(2); // Correção + desfazer
   }
 
@@ -416,8 +842,8 @@ export default function JourneyDemo() {
       await startProsa(text);
       return;
     }
-    if (stage >= 7 && negociacao === 'none') {
-      await addNegociacao(text);
+    if (stage >= 7 && evolveState === 'none') {
+      await aplicarEvolucao(text);
       return;
     }
     push({ kind: 'msg', who: 'user', text });
@@ -431,7 +857,7 @@ export default function JourneyDemo() {
   // ---------------- navegação passo a passo (◀ ▶ na topbar) ----------------
   // Avançar executa a próxima decisão do caminho feliz; Voltar re-executa a
   // jornada do zero, instantânea (reducedRef), até o passo anterior — replay
-  // determinístico, mesmo padrão do protótipo DP087.
+  // determinístico do MESMO cenário, mesmo padrão do protótipo DP087.
   const busyRef = useRef(false);
 
   const CHECKPOINTS: Array<() => Promise<void> | void> = [
@@ -441,14 +867,14 @@ export default function JourneyDemo() {
     () => montaRascunho(),
     async () => {
       if (!touchedRef.current) {
-        moveLead('ana');
+        moveRecord(CENARIOS[cenarioRef.current].seed[0].id);
         await delay(650);
       }
       await ficarComEle();
     },
     () => aprovaEnvio(),
     () => publicar(),
-    () => addNegociacao(),
+    () => aplicarEvolucao(),
   ];
 
   function proximoPasso(): number | null {
@@ -460,7 +886,7 @@ export default function JourneyDemo() {
     if (stage === 4) return 4;
     if (stage === 5) return 5;
     if (stage === 6) return 6;
-    if (stage === 7 && negociacao === 'none') return 7;
+    if (stage === 7 && evolveState === 'none') return 7;
     return null; // jornada completa
   }
 
@@ -492,17 +918,18 @@ export default function JourneyDemo() {
     setStage(0);
     setTyping(false);
     setStarted(false);
-    setFunilEditado(false);
+    setPremEditada(false);
     setBuildDone(0);
-    setStagesK(['Novo', 'Qualificado', 'Proposta', 'Contrato']);
-    setLeads([]);
+    // preserva o cenário ativo — o replay re-executa O MESMO cenário
+    setStagesK(CENARIOS[cenarioRef.current].columns);
+    setRecords([]);
     setView('kanban');
     setRecordId(null);
     setQuery('');
     setDraft('none');
     setTrust([false, false, false, false, false]);
-    setNegociacao('none');
-    setNewLeadOpen(false);
+    setEvolveState('none');
+    setNewOpen(false);
   }
 
   async function voltarPasso() {
@@ -530,40 +957,51 @@ export default function JourneyDemo() {
     setView('record');
     markTouched();
   }
-  function moveLead(id: string) {
-    setLeads((p) =>
-      p.map((l) => {
-        if (l.id !== id) return l;
-        const i = stagesK.indexOf(l.stage);
-        if (i < 0 || i >= stagesK.length - 1) return l;
+  function moveRecord(id: string) {
+    setRecords((p) =>
+      p.map((r) => {
+        if (r.id !== id) return r;
+        const i = stagesK.indexOf(r.stage);
+        if (i < 0 || i >= stagesK.length - 1) return r;
         const next = stagesK[i + 1];
-        return { ...l, stage: next, agent: false, log: [...l.log, { who: 'user', text: `Você moveu para ${next}`, time: now() }] };
+        return { ...r, stage: next, agent: false, log: [...r.log, { who: 'user', text: `Você moveu para ${next}`, time: now() }] };
       }),
     );
     markTouched();
   }
-  function createLead(name: string, company: string, email: string) {
+  function createRecord(vals: string[]) {
+    const c = CENARIOS[cenarioRef.current];
+    const base = c.newForm.build(vals);
     const id = 'novo-' + Date.now().toString(36);
-    setLeads((p) => [
+    setRecords((p) => [
       ...p,
       {
-        id, name: name || 'Gustavo Reis', company: company || 'RetailPro',
-        email: email || 'gustavo@retailpro.com', stage: 'Novo', origem: 'criado por você',
+        id,
+        name: base.name,
+        meta: base.meta,
+        stage: stagesK[0],
+        origem: 'criado por você',
+        agent: false,
         log: [{ who: 'user', text: 'Criado por você, direto na tela do rascunho', time: now() }],
       },
     ]);
-    setNewLeadOpen(false);
+    setNewOpen(false);
     markTouched();
   }
   function nbaAction(id: string) {
-    setLeads((p) =>
-      p.map((l) => {
-        if (l.id !== id) return l;
-        const i = stagesK.indexOf(l.stage);
-        const next = i >= 0 && i < stagesK.length - 1 ? stagesK[i + 1] : l.stage;
+    const c = CENARIOS[cenarioRef.current];
+    setRecords((p) =>
+      p.map((r) => {
+        if (r.id !== id) return r;
+        const nba = r.nba ?? c.nbaDefault(r);
+        if (nba.kind === 'handoff') {
+          return { ...r, log: [...r.log, { who: 'agent', text: nba.log ?? 'Encaminhado para um humano', time: now() }] };
+        }
+        const i = stagesK.indexOf(r.stage);
+        const next = i >= 0 && i < stagesK.length - 1 ? stagesK[i + 1] : r.stage;
         return {
-          ...l, stage: next, agent: true,
-          log: [...l.log, { who: 'agent', text: 'Próximo passo executado pelo assistente — com o seu OK', time: now() }],
+          ...r, stage: next, agent: true,
+          log: [...r.log, { who: 'agent', text: 'Próximo passo executado pelo assistente — com o seu OK', time: now() }],
         };
       }),
     );
@@ -571,9 +1009,11 @@ export default function JourneyDemo() {
   }
 
   // ---------------- render helpers ----------------
-  const record = leads.find((l) => l.id === recordId) ?? null;
-  const filtered = leads.filter((l) =>
-    (l.name + ' ' + l.company).toLowerCase().includes(query.toLowerCase()),
+  const cen = CENARIOS[cenarioId];
+  const entryCol = stagesK[0];
+  const record = records.find((l) => l.id === recordId) ?? null;
+  const filtered = records.filter((r) =>
+    (r.name + ' ' + cen.subtitle(r)).toLowerCase().includes(query.toLowerCase()),
   );
 
   function renderCard(item: Extract<Item, { kind: 'card' }>) {
@@ -585,9 +1025,9 @@ export default function JourneyDemo() {
           <div className={'jd-card' + (done ? ' jd-off' : '')}>
             <div className="jd-kick">Espelho — é isso?</div>
             <div className="jd-chips">
-              <span className="jd-chip on">Leads</span>
-              <span className="jd-chip on">Criadores</span>
-              <span className="jd-chip on">Contratos</span>
+              {cen.espelhoChips.map((ch) => (
+                <span key={ch} className="jd-chip on">{ch}</span>
+              ))}
               <span className="jd-chip">app novo — nada do que você já tem cobre isso</span>
             </div>
             {foot ?? (
@@ -602,23 +1042,24 @@ export default function JourneyDemo() {
           <div className={'jd-card' + (done ? ' jd-off' : '')}>
             <div className="jd-kick">Confirme como funciona — corrija por exceção</div>
             <ul className="jd-prem">
-              <li>👥 Quem usa: <b>Recrutador · Gestor · Jurídico</b></li>
-              <li>
-                🔁 Funil:{' '}
-                {funilEditado ? (
-                  <b>Novo → Qualificado → Proposta → Contrato → Onboarding <span className="jd-mini">(ajustado por você)</span></b>
-                ) : (
-                  <>
-                    <b>Novo → Qualificado → Proposta → Contrato (4 etapas)</b>{' '}
-                    {!done && (
-                      <button className="jd-link" onClick={editaFunil}>corrigir</button>
-                    )}
-                  </>
-                )}
-              </li>
-              <li>🔒 E-mail e CPF <b>protegidos por padrão</b></li>
-              <li>🛡️ Jurídico vê <b>só contratos</b></li>
-              <li>⚡ Contrato só sai <b>com o seu OK</b></li>
+              {cen.premissas.map((p, i) => (
+                <li key={i}>
+                  {isEdit(p) ? (
+                    premEditada ? (
+                      <>{p.icon} {boldify(p.after)} <span className="jd-mini">(ajustado por você)</span></>
+                    ) : (
+                      <>
+                        {p.icon} {boldify(p.before)}{' '}
+                        {!done && (
+                          <button className="jd-link" onClick={corrigirPremissa}>corrigir</button>
+                        )}
+                      </>
+                    )
+                  ) : (
+                    <>{p.icon} {boldify(p.text)}</>
+                  )}
+                </li>
+              ))}
             </ul>
             {foot ?? (
               <div className="jd-btns">
@@ -632,7 +1073,7 @@ export default function JourneyDemo() {
           <div className={'jd-card' + (done ? ' jd-off' : '')}>
             <div className="jd-kick">O desenho do seu app</div>
             <div className="jd-des">
-              {DESENHO_ROWS.map((r) => (
+              {cen.desenho.map((r) => (
                 <div key={r.label} className="jd-des-row">
                   <span className="jd-des-ic">{r.icon}</span>
                   <b>{r.label}</b>
@@ -669,12 +1110,10 @@ export default function JourneyDemo() {
         return (
           <div className={'jd-card jd-gate' + (done ? ' jd-off' : '')}>
             <div className="jd-kick jd-kick-amber">Decisão sua — o assistente espera</div>
-            <p className="jd-p">
-              O contrato da <b>Ana Souza (TechFin)</b> está pronto. Envio por Gmail?
-            </p>
+            <p className="jd-p">{boldify(cen.hitl.text)}</p>
             {foot ?? (
               <div className="jd-btns">
-                <button className="jd-btn jd-ok" onClick={aprovaEnvio}>Aprovar envio</button>
+                <button className="jd-btn jd-ok" onClick={aprovaEnvio}>{cen.hitl.button}</button>
                 <button className="jd-btn" onClick={() => resolveCard('hitl', 'Deixado para depois — fica na sua fila')}>Agora não</button>
               </div>
             )}
@@ -685,8 +1124,8 @@ export default function JourneyDemo() {
           <div className={'jd-card' + (done ? ' jd-off' : '')}>
             <div className="jd-kick">Abrir pro time?</div>
             <p className="jd-p">
-              Provado por dentro antes de expor: cada papel vê exatamente o combinado, CPF
-              protegido, automação conferida — <b>no banco, não no papel</b>.
+              Provado por dentro antes de expor: cada papel vê exatamente o combinado, dados
+              sensíveis protegidos, automação conferida — <b>no banco, não no papel</b>.
             </p>
             {foot ?? (
               <div className="jd-btns">
@@ -699,17 +1138,17 @@ export default function JourneyDemo() {
         return (
           <div className="jd-card">
             <div className="jd-kick">Evoluir é conversar</div>
-            {negociacao === 'none' ? (
+            {evolveState === 'none' ? (
               <div className="jd-btns">
-                <button className="jd-btn" onClick={() => addNegociacao()}>
-                  “adiciona a etapa Negociação antes de Contrato”
+                <button className="jd-btn" onClick={() => aplicarEvolucao()}>
+                  “{cen.evolve.userMsg.charAt(0).toLowerCase() + cen.evolve.userMsg.slice(1)}”
                 </button>
               </div>
             ) : (
               <p className="jd-p">
-                {negociacao === 'applied' ? (
+                {evolveState === 'applied' ? (
                   <>
-                    <b>Aplicado ✓</b> — etapa Negociação no pipeline.{' '}
+                    <b>Aplicado ✓</b> — {cen.evolve.doneLabel}.{' '}
                     <button className="jd-link" onClick={desfazer}>Desfazer</button>
                   </>
                 ) : (
@@ -724,7 +1163,7 @@ export default function JourneyDemo() {
           <div className="jd-card jd-cta">
             <div className="jd-kick">Isso, com os SEUS dados</div>
             <p className="jd-p">
-              Você acabou de criar, aprovar vendo e operar um app — com dados de exemplo.
+              Você acabou de criar, aprovar vendo e operar {cen.ctaObj} — com dados de exemplo.
               Com a sua planilha de verdade, é o mesmo caminho.
             </p>
             <div className="jd-btns">
@@ -807,7 +1246,7 @@ export default function JourneyDemo() {
                   <div key={i} className="jd-card">
                     <div className="jd-kick">Montando seu rascunho — zero perguntas</div>
                     <ul className="jd-build">
-                      {BUILD_STEPS.map((s, k) => (
+                      {cen.buildSteps.map((s, k) => (
                         <li key={s} className={k < buildDone ? 'done' : k === buildDone ? 'run' : ''}>
                           <span className="jd-tick">✓</span> {s}
                         </li>
@@ -827,12 +1266,11 @@ export default function JourneyDemo() {
 
           {!started && (
             <div className="jd-entries">
-              <button className="jd-pill jd-pill-imp" onClick={startPlanilha}>
-                📊 Importar planilha <code>leads-criadores.xlsx</code> <em>— opcional</em>
-              </button>
-              <button className="jd-pill" onClick={() => startProsa()}>
-                💬 “Preciso gerir leads de criadores e contratos”
-              </button>
+              {CENARIO_IDS.map((id) => (
+                <button key={id} className="jd-pill jd-pill-imp" onClick={() => startPlanilha(id)}>
+                  {CENARIOS[id].pill}
+                </button>
+              ))}
             </div>
           )}
 
@@ -868,10 +1306,10 @@ export default function JourneyDemo() {
           ) : (
             <>
               <header className="jd-app-head">
-                <b>Pipeline de Leads</b>
+                <b>{cen.appTitle}</b>
                 {badge && <span className={'jd-badge ' + badge.cls}>{badge.t}</span>}
                 <div className="jd-views" role="group" aria-label="Modo de visualização">
-                  <button className={view === 'kanban' ? 'on' : ''} onClick={() => setView('kanban')}>▦ Pipeline</button>
+                  <button className={view === 'kanban' ? 'on' : ''} onClick={() => setView('kanban')}>▦ {cen.boardLabel}</button>
                   <button className={view === 'table' ? 'on' : ''} onClick={() => { setView('table'); markTouched(); }}>☰ Tabela</button>
                   {record && (
                     <button className={view === 'record' ? 'on' : ''} onClick={() => setView('record')}>👤 {record.name.split(' ')[0]}</button>
@@ -882,25 +1320,25 @@ export default function JourneyDemo() {
               {view === 'kanban' && (
                 <div className="jd-kanban">
                   {stagesK.map((s) => {
-                    const col = leads.filter((l) => l.stage === s);
-                    const extra = s === 'Novo' ? 7 : 0;
+                    const col = records.filter((l) => l.stage === s);
+                    const extra = s === entryCol ? cen.extraN : 0;
                     return (
                       <div key={s} className="jd-kcol">
                         <div className="jd-khead">{s}<span>{col.length + extra}</span></div>
                         {col.map((l) => (
                           <div key={l.id} className="jd-kcard">
                             <button className="jd-kname" onClick={() => openRecord(l.id)}>{l.name}</button>
-                            <div className="jd-ksub">{l.company} · {mask(l.email)}</div>
+                            <div className="jd-ksub">{cen.subtitle(l)}</div>
                             <div className="jd-kfoot">
                               <span className={'jd-ktag' + (l.agent ? ' ag' : '')}>{l.agent ? 'assistente moveu' : l.origem}</span>
-                              <button className="jd-kmove" onClick={() => moveLead(l.id)} aria-label={`Mover ${l.name}`}>mover →</button>
+                              <button className="jd-kmove" onClick={() => moveRecord(l.id)} aria-label={`Mover ${l.name}`}>mover →</button>
                             </div>
                           </div>
                         ))}
-                        {s === 'Novo' && (
+                        {s === entryCol && (
                           <>
                             {extra > 0 && <div className="jd-kmore">+{extra} da planilha</div>}
-                            <button className="jd-kadd" onClick={() => setNewLeadOpen(true)}>+ Novo lead</button>
+                            <button className="jd-kadd" onClick={() => setNewOpen(true)}>{cen.newForm.add}</button>
                           </>
                         )}
                       </div>
@@ -913,73 +1351,84 @@ export default function JourneyDemo() {
                 <div className="jd-table-wrap">
                   <input
                     className="jd-search"
-                    placeholder="Buscar lead…"
+                    placeholder="Buscar…"
                     value={query}
                     onChange={(e) => setQuery(e.target.value)}
-                    aria-label="Buscar lead"
+                    aria-label="Buscar registro"
                   />
                   <table className="jd-table">
                     <thead>
-                      <tr><th>Nome</th><th>Empresa</th><th>E-mail</th><th>Etapa</th></tr>
+                      <tr>{cen.tableCols.map((c) => <th key={c.header}>{c.header}</th>)}</tr>
                     </thead>
                     <tbody>
                       {filtered.map((l) => (
                         <tr key={l.id} onClick={() => openRecord(l.id)} tabIndex={0}
                           onKeyDown={(e) => e.key === 'Enter' && openRecord(l.id)}>
-                          <td className="jd-tname">{l.name}</td>
-                          <td>{l.company}</td>
-                          <td>{mask(l.email)} 🔒</td>
-                          <td><span className="jd-stagepill">{l.stage}</span></td>
+                          {cen.tableCols.map((c) => (
+                            <td key={c.header} className={c.primary ? 'jd-tname' : undefined}>
+                              {c.stage ? (
+                                <span className="jd-stagepill">{l.stage}</span>
+                              ) : (
+                                <>{c.get?.(l)}{c.lock && ' 🔒'}</>
+                              )}
+                            </td>
+                          ))}
                         </tr>
                       ))}
                     </tbody>
                   </table>
-                  <div className="jd-tcount">{filtered.length} exibidos · {leads.length + 7} no total</div>
+                  <div className="jd-tcount">{filtered.length} exibidos · {records.length + cen.extraN} no total</div>
                 </div>
               )}
 
-              {view === 'record' && record && (
-                <div className="jd-record">
-                  <div className="jd-rec-head">
-                    <b>{record.name}</b>
-                    <span className="jd-stagepill">{record.stage}</span>
-                  </div>
-                  <div className="jd-rec-grid">
-                    <dl className="jd-fields">
-                      <div><dt>Nome</dt><dd>{record.name}</dd></div>
-                      <div><dt>Empresa</dt><dd>{record.company}</dd></div>
-                      <div>
-                        <dt>E-mail</dt>
-                        <dd>{mask(record.email)} <span className="jd-lock" title="Protegido: seu papel vê mascarado — decidido no desenho">🔒</span></dd>
+              {view === 'record' && record && (() => {
+                const nba = record.nba ?? cen.nbaDefault(record);
+                const handoff = nba.kind === 'handoff';
+                return (
+                  <div className="jd-record">
+                    <div className="jd-rec-head">
+                      <b>{record.name}</b>
+                      <span className="jd-stagepill">{record.stage}</span>
+                    </div>
+                    <div className="jd-rec-grid">
+                      <dl className="jd-fields">
+                        {cen.recordFields(record).map((f) => (
+                          <div key={f.label}>
+                            <dt>{f.label}</dt>
+                            <dd>
+                              {f.value}
+                              {f.lock && (
+                                <span className="jd-lock" title="Protegido: seu papel vê mascarado — decidido no desenho"> 🔒</span>
+                              )}
+                            </dd>
+                          </div>
+                        ))}
+                      </dl>
+                      <div className={'jd-nba' + (handoff ? ' jd-nba-hand' : '')}>
+                        <span className="jd-nba-k">{handoff ? '🙋 Humano assume' : '🤖 Próximo passo sugerido'}</span>
+                        <span>{nba.text}</span>
+                        <button className="jd-btn jd-pri" onClick={() => nbaAction(record.id)}>Fazer isso</button>
                       </div>
-                      <div><dt>Etapa</dt><dd>{record.stage}</dd></div>
-                      <div><dt>Dono</dt><dd>Recrutador (você)</dd></div>
-                    </dl>
-                    <div className="jd-nba">
-                      <span className="jd-nba-k">🤖 Próximo passo sugerido</span>
-                      <span>
-                        {record.stage === 'Novo'
-                          ? 'Qualificar este lead — os dados vieram completos.'
-                          : record.stage === 'Contrato'
-                            ? 'Acompanhar a assinatura — contrato enviado.'
-                            : 'Avançar para a próxima etapa do funil.'}
-                      </span>
-                      <button className="jd-btn jd-pri" onClick={() => nbaAction(record.id)}>Fazer isso</button>
+                    </div>
+                    <div className="jd-tl">
+                      <span className="jd-tl-t">Histórico — tudo fica registrado</span>
+                      {record.log.map((e, i) => (
+                        <div key={i} className={'jd-tl-i ' + e.who}>
+                          <span>{e.text}</span><time>{e.time}</time>
+                        </div>
+                      ))}
                     </div>
                   </div>
-                  <div className="jd-tl">
-                    <span className="jd-tl-t">Histórico — tudo fica registrado</span>
-                    {record.log.map((e, i) => (
-                      <div key={i} className={'jd-tl-i ' + e.who}>
-                        <span>{e.text}</span><time>{e.time}</time>
-                      </div>
-                    ))}
-                  </div>
-                </div>
-              )}
+                );
+              })()}
 
-              {newLeadOpen && (
-                <NewLeadForm onCreate={createLead} onCancel={() => setNewLeadOpen(false)} />
+              {newOpen && (
+                <NewRecordForm
+                  title={cen.newForm.title}
+                  fields={cen.newForm.fields}
+                  onCreate={createRecord}
+                  onCancel={() => setNewOpen(false)}
+                />
               )}
             </>
           )}
@@ -1033,26 +1482,32 @@ export default function JourneyDemo() {
   );
 }
 
-function NewLeadForm({
+function NewRecordForm({
+  title,
+  fields,
   onCreate,
   onCancel,
 }: {
-  onCreate: (n: string, c: string, e: string) => void;
+  title: string;
+  fields: { label: string; def: string }[];
+  onCreate: (vals: string[]) => void;
   onCancel: () => void;
 }) {
-  const [n, setN] = useState('Gustavo Reis');
-  const [c, setC] = useState('RetailPro');
-  const [e, setE] = useState('gustavo@retailpro.com');
+  const [vals, setVals] = useState<string[]>(fields.map((f) => f.def));
+  const setAt = (i: number, v: string) => setVals((p) => p.map((x, k) => (k === i ? v : x)));
   return (
-    <div className="jd-modal" role="dialog" aria-modal="true" aria-label="Criar novo lead">
+    <div className="jd-modal" role="dialog" aria-modal="true" aria-label={title}>
       <div className="jd-modal-card">
-        <b>Novo lead</b>
-        <label>Nome<input value={n} onChange={(ev) => setN(ev.target.value)} /></label>
-        <label>Empresa<input value={c} onChange={(ev) => setC(ev.target.value)} /></label>
-        <label>E-mail<input value={e} onChange={(ev) => setE(ev.target.value)} /></label>
+        <b>{title}</b>
+        {fields.map((f, i) => (
+          <label key={f.label}>
+            {f.label}
+            <input value={vals[i]} onChange={(ev) => setAt(i, ev.target.value)} />
+          </label>
+        ))}
         <span className="jd-mini">🛡️ Vira registro real no seu espaço — protegido e só seu.</span>
         <div className="jd-btns">
-          <button className="jd-btn jd-pri" onClick={() => onCreate(n, c, e)}>Criar</button>
+          <button className="jd-btn jd-pri" onClick={() => onCreate(vals)}>Criar</button>
           <button className="jd-btn" onClick={onCancel}>Cancelar</button>
         </div>
       </div>
@@ -1239,6 +1694,8 @@ const JD_CSS = `
 .jd-lock { cursor:help; font-size:12px; }
 .jd-nba { border:1px solid rgba(77,171,247,.35); background:rgba(77,171,247,.07); border-radius:10px; padding:12px; display:flex; flex-direction:column; gap:8px; font-size:13px; }
 .jd-nba-k { font-size:10.5px; text-transform:uppercase; letter-spacing:.07em; color:var(--jd-blue); font-weight:700; }
+.jd-nba-hand { border-color:rgba(251,191,36,.45); background:rgba(251,191,36,.07); }
+.jd-nba-hand .jd-nba-k { color:var(--jd-amber); }
 .jd-tl { margin-top:16px; }
 .jd-tl-t { display:block; font-size:10.5px; text-transform:uppercase; letter-spacing:.06em; color:var(--jd-mut); font-weight:700; margin-bottom:8px; }
 .jd-tl-i { display:flex; gap:10px; border-left:2px solid var(--jd-line); padding:6px 0 6px 12px; position:relative; font-size:13px; color:var(--jd-mut); }

--- a/src/components/JourneyDemo.tsx
+++ b/src/components/JourneyDemo.tsx
@@ -111,6 +111,15 @@ const INITIAL_ITEMS: Item[] = [
   },
 ];
 
+// Exemplos que ciclam no placeholder da entrada (máquina-de-escrever). Cada um
+// casa com o roteamento por regex (lead→leads · cobran/caixa→caixa · whatsapp→
+// atendimento), então copiar a sugestão e enviar leva ao cenário certo.
+const ENTRY_EXAMPLES = [
+  'meus leads e contratos vivem numa planilha…',
+  'cobrança de clientes em atraso, tudo no caixa…',
+  'minha clínica se afoga em mensagens no WhatsApp…',
+];
+
 // ======================= CENÁRIOS =======================
 
 type CenarioId = 'leads' | 'caixa' | 'atendimento';
@@ -605,6 +614,11 @@ export default function JourneyDemo() {
   const [evolveState, setEvolveState] = useState<'none' | 'applied' | 'undone'>('none');
   const [newOpen, setNewOpen] = useState(false);
   const [chatText, setChatText] = useState('');
+  // digitação emulada (autopilot): mostra a mensagem do VC sendo digitada no
+  // input real antes de virar bolha — dá a sensação de "alguém usando de verdade".
+  const [emulating, setEmulating] = useState(false);
+  // placeholder máquina-de-escrever na tela de entrada (antes de started)
+  const [phText, setPhText] = useState('');
   // mobile: um painel por vez (chat ⇄ app), padrão do protótipo DP087
   const [pane, setPane] = useState<'chat' | 'app'>('chat');
   const [touched, setTouched] = useState(false);
@@ -613,6 +627,9 @@ export default function JourneyDemo() {
   const genRef = useRef(0);
   const reducedRef = useRef(false);
   const scrollRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const emulatingRef = useRef(false); // trava síncrona da emulação de digitação
+  const skipRef = useRef(false); // clique no input → conclui a emulação na hora
   const touchedRef = useRef(false);
   // cenário ativo, síncrono — sobrevive ao resetAll do replay (voltar re-executa
   // O MESMO cenário). Só muda antes de started (pill) ou via roteamento do texto livre.
@@ -647,6 +664,56 @@ export default function JourneyDemo() {
     if (n) n.scrollTop = n.scrollHeight;
   }, [items, typing]);
 
+  // placeholder máquina-de-escrever na entrada: cicla os exemplos dos 3 cenários.
+  // Roda no idle da tela de entrada; para quando o usuário digita (chatText != '')
+  // e retoma se limpar. Respeita prefers-reduced-motion (fica estático).
+  useEffect(() => {
+    if (started || reducedRef.current || chatText !== '') {
+      setPhText('');
+      return;
+    }
+    let cancelled = false;
+    let timer: ReturnType<typeof setTimeout>;
+    let ti = 0; // exemplo
+    let ci = 0; // caractere
+    let mode: 'typing' | 'pause' | 'deleting' = 'typing';
+    const tick = () => {
+      if (cancelled) return;
+      const ex = ENTRY_EXAMPLES[ti];
+      if (mode === 'typing') {
+        ci += 1;
+        setPhText(ex.slice(0, ci));
+        if (ci >= ex.length) {
+          mode = 'pause';
+          timer = setTimeout(tick, 1800);
+        } else {
+          timer = setTimeout(tick, 45 + Math.random() * 30);
+        }
+      } else if (mode === 'pause') {
+        mode = 'deleting';
+        timer = setTimeout(tick, 30);
+      } else {
+        ci -= 2;
+        if (ci <= 1) {
+          // pula pro próximo exemplo já com 1 char — nunca fica vazio (sem flash)
+          ti = (ti + 1) % ENTRY_EXAMPLES.length;
+          ci = 1;
+          mode = 'typing';
+          setPhText(ENTRY_EXAMPLES[ti].slice(0, 1));
+          timer = setTimeout(tick, 220);
+        } else {
+          setPhText(ex.slice(0, ci));
+          timer = setTimeout(tick, 25);
+        }
+      }
+    };
+    timer = setTimeout(tick, 600);
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+    };
+  }, [started, chatText]);
+
   const now = () => {
     clockRef.current += 1;
     return `14:${String(clockRef.current).padStart(2, '0')}`;
@@ -666,6 +733,47 @@ export default function JourneyDemo() {
     if (genRef.current !== gen) return; // recomeçar/rebuild cancelou esta fala
     setTyping(false);
     push({ kind: 'msg', who: 'ally', text });
+  }
+
+  // Emula digitação humana da mensagem do VC no input real e então a envia como
+  // bolha. Caret fake via CSS (sem foco programático — evita abrir o teclado no
+  // mobile). No replay/reduced-motion, ou se o usuário estiver escrevendo de
+  // verdade, cai direto na bolha. Cancelável pela guarda de época (genRef).
+  async function typeThenPush(text: string) {
+    const gen = genRef.current;
+    const el = inputRef.current;
+    const userBusy = !!(el && (el.value.trim() !== '' || document.activeElement === el));
+    if (reducedRef.current || userBusy) {
+      push({ kind: 'msg', who: 'user', text });
+      return;
+    }
+    const finish = (send: boolean) => {
+      emulatingRef.current = false;
+      setEmulating(false);
+      setChatText('');
+      if (send) push({ kind: 'msg', who: 'user', text });
+    };
+    skipRef.current = false;
+    emulatingRef.current = true;
+    setEmulating(true);
+    const chars = Array.from(text);
+    // ~35ms/char, mas acelera frases longas para caber em ~2,5s
+    const per = chars.length * 35 > 2500 ? Math.max(8, Math.floor(2500 / chars.length)) : 35;
+    let acc = '';
+    for (const ch of chars) {
+      if (genRef.current !== gen) return finish(false); // recomeçar cancelou
+      if (skipRef.current) break; // clique no input → conclui na hora
+      acc += ch;
+      setChatText(acc);
+      let d = per + (Math.random() * 40 - 20); // jitter ±20ms = irregular, humano
+      if (/[.,!?;:—…]/.test(ch)) d += 90; // pausa um pouco maior na pontuação
+      await delay(Math.max(8, d));
+    }
+    if (skipRef.current) setChatText(text);
+    if (genRef.current !== gen) return finish(false);
+    await delay(skipRef.current ? 80 : 250);
+    if (genRef.current !== gen) return finish(false);
+    finish(true);
   }
 
   const earn = (i: number) =>
@@ -703,7 +811,8 @@ export default function JourneyDemo() {
     if (id) aplicarCenario(id);
     const c = CENARIOS[cid];
     track('jornada_start', { entry: 'planilha', cenario: cid });
-    push({ kind: 'msg', who: 'user', text: `📎 ${c.xlsx}` });
+    await typeThenPush(`📎 ${c.xlsx}`);
+    if (genRef.current !== gen) return;
     await ally(c.planilhaRead, 900);
     if (genRef.current !== gen) return;
     push({ kind: 'card', card: 'espelho' });
@@ -747,7 +856,7 @@ export default function JourneyDemo() {
       const col = ep.addColuna;
       setStagesK((p) => (p.includes(col) ? p : [...p, col]));
     }
-    push({ kind: 'msg', who: 'user', text: ep.userMsg });
+    await typeThenPush(ep.userMsg);
     await ally(ep.ally, 450);
   }
 
@@ -840,7 +949,7 @@ export default function JourneyDemo() {
     if (!lock('ajustar')) return;
     const c = CENARIOS[cenarioRef.current];
     const alvo = c.columns[2];
-    push({ kind: 'msg', who: 'user', text: `Queria ${alvo} logo depois de ${c.columns[0]}.` });
+    await typeThenPush(`Queria ${alvo} logo depois de ${c.columns[0]}.`);
     await ally('Troquei — olha a tela. Ajustar rascunho é conversa, não retrabalho. É isso?', 500);
     setStagesK((p) => {
       const rest = p.filter((s) => s !== alvo);
@@ -907,8 +1016,15 @@ export default function JourneyDemo() {
     const c = CENARIOS[cenarioRef.current];
     const gen = genRef.current;
     const ev = c.evolve;
-    push({ kind: 'msg', who: 'user', text: viaChat ?? ev.userMsg });
-    if (viaChat) await ally(ev.allyViaChat, 550);
+    // texto livre (viaChat) já foi digitado pelo usuário → bolha direta;
+    // no autopilot, emula a digitação do pedido do roteiro.
+    if (viaChat) {
+      push({ kind: 'msg', who: 'user', text: viaChat });
+      await ally(ev.allyViaChat, 550);
+    } else {
+      await typeThenPush(ev.userMsg);
+    }
+    if (genRef.current !== gen) return;
     await delay(450);
     if (genRef.current !== gen) return;
     if (ev.col && ev.before) {
@@ -958,6 +1074,7 @@ export default function JourneyDemo() {
 
   // ---------------- chat livre: você escreve, a demo responde ----------------
   async function enviarChat() {
+    if (emulatingRef.current) return; // digitação emulada em curso — ignora envio real
     const text = chatText.trim();
     if (!text || busyRef.current) return;
     setChatText('');
@@ -1032,10 +1149,14 @@ export default function JourneyDemo() {
   }
 
   function resetAll() {
-    genRef.current += 1; // cancela loops de build em andamento
+    genRef.current += 1; // cancela loops de build e digitação emulada em andamento
     lockRef.current.clear();
     startedRef.current = false;
     touchedRef.current = false;
+    emulatingRef.current = false;
+    skipRef.current = false;
+    setEmulating(false);
+    setChatText('');
     setTouched(false);
     setPane('chat');
     clockRef.current = 31;
@@ -1636,20 +1757,33 @@ export default function JourneyDemo() {
           )}
 
           {/* input de chat — a conversa é o modelo de interação, sempre visível */}
-          <div className="jd-input">
-            <input
-              value={chatText}
-              onChange={(e) => setChatText(e.target.value)}
-              onKeyDown={(e) => {
-                if (e.key === 'Enter') enviarChat();
-              }}
-              placeholder={
-                started
-                  ? 'Escreva aqui — ex.: adiciona uma etapa no funil…'
-                  : 'Ou escreva com as suas palavras o problema do seu negócio…'
-              }
-              aria-label="Mensagem para o assistente"
-            />
+          <div className={'jd-input' + (emulating ? ' jd-input-emul' : '')}>
+            <div className="jd-input-field">
+              <input
+                ref={inputRef}
+                value={chatText}
+                readOnly={emulating}
+                onChange={(e) => setChatText(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') enviarChat();
+                }}
+                onMouseDown={() => {
+                  if (emulatingRef.current) skipRef.current = true; // clique conclui na hora
+                }}
+                placeholder={
+                  started
+                    ? 'Escreva aqui — ex.: adiciona uma etapa no funil…'
+                    : phText || 'Ou escreva com as suas palavras o problema do seu negócio…'
+                }
+                aria-label="Mensagem para o assistente"
+              />
+              {emulating && (
+                <div className="jd-ghost" aria-hidden="true">
+                  <span className="jd-ghost-t">{chatText}</span>
+                  <span className="jd-caret" />
+                </div>
+              )}
+            </div>
             <button className="jd-send" onClick={enviarChat} aria-label="Enviar mensagem">
               ➤
             </button>
@@ -2130,9 +2264,16 @@ const JD_CSS = `
 .jd-trust-chip.on { color:var(--jd-green); border-color:rgba(52,211,153,.4); background:rgba(52,211,153,.08); opacity:1; }
 .jd-honest { font-size:12px; color:var(--jd-mut); text-align:center; padding:10px 16px 14px; margin:0; }
 .jd-input { display:flex; gap:8px; padding:10px 14px; border-top:1px solid var(--jd-line); }
-.jd-input input { flex:1; min-width:0; background:rgba(255,255,255,.05); border:1px solid var(--jd-line); border-radius:10px; padding:9px 13px; color:var(--jd-tx); font:inherit; font-size:13.5px; }
-.jd-input input::placeholder { color:var(--jd-mut); }
-.jd-input input:focus { outline:none; border-color:var(--jd-blue); box-shadow:0 0 0 3px rgba(77,171,247,.18); }
+.jd-input-field { position:relative; flex:1; min-width:0; display:flex; }
+.jd-input-field input { flex:1; min-width:0; background:rgba(255,255,255,.05); border:1px solid var(--jd-line); border-radius:10px; padding:9px 13px; color:var(--jd-tx); font:inherit; font-size:13.5px; }
+.jd-input-field input::placeholder { color:var(--jd-mut); }
+.jd-input-field input:focus { outline:none; border-color:var(--jd-blue); box-shadow:0 0 0 3px rgba(77,171,247,.18); }
+/* digitação emulada: esconde o texto real do input; o ghost mostra com caret fake */
+.jd-input-emul .jd-input-field input { color:transparent; }
+.jd-ghost { position:absolute; inset:0; padding:0 13px; border:1px solid transparent; display:flex; align-items:center; overflow:hidden; pointer-events:none; }
+.jd-ghost-t { font:inherit; font-size:13.5px; color:var(--jd-tx); white-space:pre; }
+.jd-caret { display:inline-block; width:2px; height:1.05em; margin-left:1px; background:var(--jd-blue); animation:jd-caretblink 1.05s step-end infinite; }
+@keyframes jd-caretblink { 0%,50%{opacity:1} 50.01%,100%{opacity:0} }
 .jd-send { border:none; background:var(--jd-blue); color:#fff; width:38px; border-radius:10px; cursor:pointer; font-size:13px; }
 .jd-send:hover { filter:brightness(1.1); }
 .jd :focus-visible { outline:2px solid var(--jd-blue); outline-offset:2px; border-radius:6px; }


### PR DESCRIPTION
## O que entrega

A jornada interativa de /demo agora tem **3 cenários** — os mesmos do catálogo do BCM (deck de vendas):

- **📊 Leads e contratos** (o original, preservado)
- **💰 Fluxo de caixa e cobrança** — a história do Ricardo: régua de cobrança corrigida por exceção ("4 toques"), painel de recebíveis, HITL = cobrança da fatura vencida com parcelamento (decisão de dinheiro → humano aprova), evolve +Acordo
- **📅 Atendimento no WhatsApp que resolve** (anti-chatbot por construção: "atende E executa; não é um chat que só responde") — HITL = confirmar agendamento do José; a ficha da Paula encena **Humano assume** (assunto clínico → "não respondo isso: passo para a equipe agora")

Texto livre roteia por assunto (faturas/cobrança → caixa; agendamento/WhatsApp → atendimento; senão leads), mantendo as palavras do visitante na conversa.

## Mecânica preservada (verificação independente no browser)
Autopilot ◀▶ dirige os 3 cenários ponta a ponta; replay ◀ mantém o cenário; colunas do evolve inseridas na posição certa nos 3; travas de duplo clique; toggle mobile; máscaras CPF/CNPJ/e-mail; léxico limpo (zero "chatbot", zero concorrentes); 3 pills cabem a 390px sem overflow; tsc + build verdes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LjPRKoN7vVMbfPHXFsFun4