### PR TITLE
feat(seo): sitemap, robots e JSON-LD (Organization, WebSite, FAQPage)

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -39,6 +39,23 @@ export const metadata: Metadata = {
   },
 };
 
+// JSON-LD (schema.org) — dados estruturados da organização e do site.
+const ORGANIZATION_JSONLD = {
+  '@context': 'https://schema.org',
+  '@type': 'Organization',
+  name: 'Fluxomind',
+  url: 'https://www.fluxomind.com',
+  logo: 'https://www.fluxomind.com/logoSVG/logo-dark.svg',
+  email: 'contato@fluxomind.com',
+};
+
+const WEBSITE_JSONLD = {
+  '@context': 'https://schema.org',
+  '@type': 'WebSite',
+  name: 'Fluxomind',
+  url: 'https://www.fluxomind.com',
+};
+
 export default function RootLayout({
   children,
 }: {
@@ -47,6 +64,14 @@ export default function RootLayout({
   return (
     <html lang="pt-BR" className={inter.variable}>
       <body>
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(ORGANIZATION_JSONLD) }}
+        />
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(WEBSITE_JSONLD) }}
+        />
         {children}
         <Analytics />
       </body>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -75,6 +75,55 @@ const PHASE_CARDS = [
   { badge: 'b-road', ...PHASE.vision },
 ];
 
+// JSON-LD (schema.org) da seção de FAQ — espelha as perguntas e respostas
+// renderizadas abaixo; ao mudar a copy da seção, atualize aqui também.
+const FAQ_JSONLD = {
+  '@context': 'https://schema.org',
+  '@type': 'FAQPage',
+  mainEntity: [
+    {
+      '@type': 'Question',
+      name: 'Preciso saber programar?',
+      acceptedAnswer: {
+        '@type': 'Answer',
+        text: 'Não. Você descreve o problema em português; o app se constrói e, para mudar, você conversa. Sem dev no caminho.',
+      },
+    },
+    {
+      '@type': 'Question',
+      name: 'Meus dados ficam seguros?',
+      acceptedAnswer: {
+        '@type': 'Answer',
+        text: 'Cada empresa fica isolada de verdade, os dados são criptografados e toda ação fica numa trilha à prova de adulteração. Quem exige pode trazer a própria chave. Os detalhes estão na página de Segurança.',
+      },
+    },
+    {
+      '@type': 'Question',
+      name: 'Vou ter que largar minha planilha ou meu CRM?',
+      acceptedAnswer: {
+        '@type': 'Answer',
+        text: 'Não. O app nasce integrado ao que você já tem — WhatsApp, e-mail, API, seus sistemas — e você migra no seu ritmo.',
+      },
+    },
+    {
+      '@type': 'Question',
+      name: 'Em quanto tempo estou rodando?',
+      acceptedAnswer: {
+        '@type': 'Answer',
+        text: 'Em semanas, não num projeto de meses. No beta, o time acompanha de perto: o primeiro caso a gente monta com você.',
+      },
+    },
+    {
+      '@type': 'Question',
+      name: 'Quanto custa?',
+      acceptedAnswer: {
+        '@type': 'Answer',
+        text: 'Durante o beta, ninguém pede cartão: o acesso é acompanhado e sem custo para começar. Os planos estão na página de Preços.',
+      },
+    },
+  ],
+};
+
 export default function Home() {
   return (
     <div className="page-home">
@@ -400,6 +449,10 @@ export default function Home() {
       </section>
 
       {/* FAQ */}
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(FAQ_JSONLD) }}
+      />
       <section id="faq" style={{ paddingTop: 0 }}>
         <div className="wrap">
           <div className="center">

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,12 @@
+import type { MetadataRoute } from 'next';
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: '*',
+      allow: '/',
+      disallow: ['/admin', '/api'],
+    },
+    sitemap: 'https://www.fluxomind.com/sitemap.xml',
+  };
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,19 @@
+import type { MetadataRoute } from 'next';
+
+const BASE_URL = 'https://www.fluxomind.com';
+
+// lastModified omitido de propósito: um new Date() dinâmico mudaria o XML a
+// cada build sem mudança real de conteúdo.
+export default function sitemap(): MetadataRoute.Sitemap {
+  return [
+    { url: `${BASE_URL}/`, changeFrequency: 'weekly', priority: 1 },
+    { url: `${BASE_URL}/demo`, changeFrequency: 'monthly', priority: 0.9 },
+    { url: `${BASE_URL}/o-que-tem`, changeFrequency: 'monthly', priority: 0.8 },
+    { url: `${BASE_URL}/plataforma`, changeFrequency: 'monthly', priority: 0.8 },
+    { url: `${BASE_URL}/acelere`, changeFrequency: 'monthly', priority: 0.7 },
+    { url: `${BASE_URL}/por-que`, changeFrequency: 'monthly', priority: 0.7 },
+    { url: `${BASE_URL}/precos`, changeFrequency: 'monthly', priority: 0.7 },
+    { url: `${BASE_URL}/seguranca`, changeFrequency: 'monthly', priority: 0.7 },
+    { url: `${BASE_URL}/terms`, changeFrequency: 'yearly', priority: 0.3 },
+  ];
+}


### PR DESCRIPTION
## O que muda

SEO técnico do site — sitemap, robots e dados estruturados (schema.org).

- **`src/app/sitemap.ts`** — 9 rotas públicas (`/`, `/demo`, `/o-que-tem`, `/plataforma`, `/acelere`, `/por-que`, `/precos`, `/seguranca`, `/terms`) na base `https://www.fluxomind.com`. Sem `/admin` nem `/api`. Prioridades: home 1.0, `/demo` 0.9, páginas de conteúdo 0.7–0.8, `/terms` 0.3. Sem `lastModified` dinâmico — o XML não muda a cada build.
- **`src/app/robots.ts`** — allow geral, disallow `/admin` e `/api`, aponta `https://www.fluxomind.com/sitemap.xml`.
- **`src/app/layout.tsx`** — JSON-LD `Organization` (logo real `/logoSVG/logo-dark.svg`, email `contato@fluxomind.com`, sem `sameAs` inventado) e `WebSite`. `metadataBase` já existia — sem mudança.
- **`src/app/page.tsx`** — JSON-LD `FAQPage` espelhando as 5 perguntas/respostas reais da seção de FAQ da home (copy idêntica, links viram texto).

## Verificação

- `npx tsc --noEmit` verde
- `npm run build` verde, com `/robots.txt` e `/sitemap.xml` nas rotas
- Os 3 blocos JSON-LD do HTML pré-renderizado da home passam em `JSON.parse` (Organization, WebSite, FAQPage)
- `robots.txt` e `sitemap.xml` gerados conferidos no output do build

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RxHVLNcnKp8AVif5sEuuh3