### PR TITLE
feat(demo): Ally vira a persona pública da jornada

### DIFF
--- a/docs/message-house-cliente-final.md
+++ b/docs/message-house-cliente-final.md
@@ -97,5 +97,5 @@ A conversão principal do site é **viver a demonstração** — o encantamento 
 | `/seguranca` | As 5 regras da confiança + governança | Sóbrio, verificável |
 | `/precos` | Beta honesto: acompanhado, sem cartão; sem números inventados | Direto, sem fricção |
 | `/por-que` | O propósito, na palavra do fundador (3 atos, assinada e datada) | Pessoal, primeira pessoa, sem hipérbole |
-| `/demo` | Jornada interativa dirigida pelo visitante (espelho → aprova-o-que-vê → operar → evoluir) | Encantamento com moldura de fase ("o produto que estamos construindo"); persona = "assistente" (Ally é interno até decisão do fundador) |
+| `/demo` | Jornada interativa dirigida pelo visitante (espelho → aprova-o-que-vê → operar → evoluir) | Encantamento com moldura de fase ("o produto que estamos construindo"); **persona pública = Ally** (voz da criação/operação com o criador — decisão do fundador, 2026-07-03; antes era interna). O agente **dentro do app do cliente** (thread do WhatsApp, execução de cobrança, etc.) permanece **"o assistente" genérico** — o cliente final não conhece a Ally. Gênero: "a Ally". |
 | `/terms` | Legal | Inalterado em conteúdo; marca "Fluxomind" |

--- a/src/components/JourneyDemo.tsx
+++ b/src/components/JourneyDemo.tsx
@@ -1671,6 +1671,7 @@ export default function JourneyDemo() {
         </span>
         <div className="jd-top-nav" role="group" aria-label="Navegar pela jornada passo a passo">
           <button
+            className="jd-nav-back"
             onClick={voltarPasso}
             aria-label="Voltar um passo"
             title="Voltar um passo"
@@ -1679,7 +1680,12 @@ export default function JourneyDemo() {
             ◀
           </button>
           <span className="jd-top-nav-lbl">passo a passo</span>
-          <button onClick={avancarPasso} aria-label="Avançar um passo" title="Avançar um passo">
+          <button
+            className="jd-nav-fwd"
+            onClick={avancarPasso}
+            aria-label="Avançar um passo"
+            title="Avançar um passo"
+          >
             ▶
           </button>
         </div>
@@ -2021,9 +2027,12 @@ const JD_CSS = `
 .jd-top-crumb i { font-style:normal; opacity:.5; margin:0 2px; }
 .jd-top-crumb b { color:var(--jd-tx); font-weight:600; }
 .jd-top-nav { margin-left:auto; display:flex; align-items:center; gap:2px; border:1px solid var(--jd-line); border-radius:999px; padding:2px 4px; }
-.jd-top-nav button { border:none; background:none; color:var(--jd-tx); font-size:12px; width:26px; height:24px; border-radius:99px; cursor:pointer; }
-.jd-top-nav button:hover:not(:disabled) { background:rgba(255,255,255,.08); }
-.jd-top-nav button:disabled { color:var(--jd-mut); opacity:.4; cursor:default; }
+.jd-top-nav button { border:none; font-size:12px; width:26px; height:24px; border-radius:99px; cursor:pointer; color:#fff; }
+.jd-top-nav button.jd-nav-fwd { background:#2B66DD; }
+.jd-top-nav button.jd-nav-fwd:hover:not(:disabled) { background:#3d76ec; }
+.jd-top-nav button.jd-nav-back { background:#b83a3a; }
+.jd-top-nav button.jd-nav-back:hover:not(:disabled) { background:#cc4a4a; }
+.jd-top-nav button:disabled { background:rgba(255,255,255,.06); color:var(--jd-mut); opacity:.4; cursor:default; }
 .jd-top-nav-lbl { font-size:10.5px; color:var(--jd-mut); letter-spacing:.04em; padding:0 2px; }
 @media (max-width:560px){ .jd-top-nav-lbl{ display:none; } }
 .jd-top-restart { display:flex; align-items:center; gap:4px; border:1px solid var(--jd-line); background:none; color:var(--jd-tx); font:inherit; font-size:12px; font-weight:600; border-radius:999px; padding:5px 11px; cursor:pointer; white-space:nowrap; }

--- a/src/components/JourneyDemo.tsx
+++ b/src/components/JourneyDemo.tsx
@@ -107,7 +107,7 @@ const INITIAL_ITEMS: Item[] = [
   {
     kind: 'msg',
     who: 'ally',
-    text: 'Oi! 👋 Escolha um exemplo aqui embaixo — ou me conta um problema do seu negócio com as suas palavras, que eu leio como você trabalha hoje. Os dois caminhos valem.',
+    text: 'Oi! Eu sou a Ally 👋 Escolha um exemplo aqui embaixo — ou me conta um problema do seu negócio com as suas palavras, que eu leio como você trabalha hoje. Os dois caminhos valem.',
   },
 ];
 
@@ -157,7 +157,7 @@ type Cenario = {
   tema: string; // roteiro do texto livre
   // entrada
   xlsx: string; // "contas-a-receber.xlsx (2 abas · 22 linhas)"
-  planilhaRead: string; // fala do assistente ao ler a planilha
+  planilhaRead: string; // fala da Ally ao ler a planilha
   espelhoChips: string[];
   // enquadrar
   premissas: Premissa[];
@@ -925,7 +925,7 @@ export default function JourneyDemo() {
     setDraft('kept');
     track('jornada_keep');
     goStage(5);
-    await ally('Agora o assistente assume o dia a dia — e te pergunta antes do que importa. Olha ele trabalhando:', 700);
+    await ally('Agora a Ally assume o dia a dia — e te pergunta antes do que importa. Olha ela trabalhando:', 700);
     if (genRef.current !== gen) return;
     const am = c.autoMove;
     setRecords((p) =>
@@ -1379,7 +1379,7 @@ export default function JourneyDemo() {
       case 'hitl':
         return (
           <div className={'jd-card jd-gate' + (done ? ' jd-off' : '')}>
-            <div className="jd-kick jd-kick-amber">Decisão sua — o assistente espera</div>
+            <div className="jd-kick jd-kick-amber">Decisão sua — a Ally espera</div>
             <p className="jd-p">{boldify(cen.hitl.text)}</p>
             {foot ?? (
               <div className="jd-btns">
@@ -1667,7 +1667,7 @@ export default function JourneyDemo() {
           fluxomind
         </Link>
         <span className="jd-top-crumb">
-          sua-empresa <i>/</i> Assistente — <b>Jornada de criação</b>
+          sua-empresa <i>/</i> Ally — <b>Jornada de criação</b>
         </span>
         <div className="jd-top-nav" role="group" aria-label="Navegar pela jornada passo a passo">
           <button
@@ -1718,7 +1718,7 @@ export default function JourneyDemo() {
               if (it.kind === 'msg')
                 return (
                   <div key={i} className={'jd-msg ' + it.who}>
-                    <span className="jd-who">{it.who === 'ally' ? 'AI' : 'VC'}</span>
+                    <span className="jd-who">{it.who === 'ally' ? 'Ally' : 'VC'}</span>
                     <span className="jd-bubble">{it.text}</span>
                   </div>
                 );
@@ -1740,7 +1740,7 @@ export default function JourneyDemo() {
             })}
             {typing && (
               <div className="jd-msg ally">
-                <span className="jd-who">AI</span>
+                <span className="jd-who">Ally</span>
                 <span className="jd-bubble jd-typing"><i /><i /><i /></span>
               </div>
             )}
@@ -1775,7 +1775,7 @@ export default function JourneyDemo() {
                     ? 'Escreva aqui — ex.: adiciona uma etapa no funil…'
                     : phText || 'Ou escreva com as suas palavras o problema do seu negócio…'
                 }
-                aria-label="Mensagem para o assistente"
+                aria-label="Mensagem para a Ally"
               />
               {emulating && (
                 <div className="jd-ghost" aria-hidden="true">
@@ -2085,6 +2085,7 @@ const JD_CSS = `
 .jd-msg { display:flex; gap:8px; max-width:94%; }
 .jd-msg.user { align-self:flex-end; flex-direction:row-reverse; }
 .jd-who { width:26px;height:26px;min-width:26px;border-radius:999px;display:flex;align-items:center;justify-content:center;font-size:10px;font-weight:700;background:rgba(77,171,247,.15);color:var(--jd-blue); }
+.jd-msg.ally .jd-who { font-size:8.5px; letter-spacing:-.02em; } /* "Ally" (4 letras) cabe no círculo */
 .jd-msg.user .jd-who { background:rgba(167,139,250,.15); color:#A78BFA; }
 .jd-bubble { background:var(--jd-panel); border:1px solid var(--jd-line); border-radius:12px; padding:9px 13px; line-height:1.5; }
 .jd-msg.user .jd-bubble { background:rgba(77,171,247,.1); border-color:rgba(77,171,247,.25); }


### PR DESCRIPTION
## O quê

Decisão do fundador (2026-07-03): **Ally deixa de ser interna** e vira a persona pública da jornada — a voz da **criação/operação que fala COM o criador**.

## Vira "Ally" (voz com o criador, no chat da jornada)

- **Crumb**: `Assistente — Jornada de criação` → `Ally — Jornada de criação`
- **Avatar** das bolhas da assistente: `AI` → `Ally` (fonte do chip ajustada p/ caber no círculo de 26px)
- **Saudação** apresenta a persona: "Oi! Eu sou a Ally 👋 …"
- **aria-label** do input: "Mensagem para o assistente" → "Mensagem para a Ally"
- **Narração**: "o assistente assume o dia a dia … Olha ele" → "a Ally assume o dia a dia … Olha ela"; **kick do HITL** "o assistente espera" → "a Ally espera"
- Gênero: **a Ally**

## PERMANECE "o assistente" genérico (agente DENTRO do app do cliente)

O cliente final (paciente da clínica, devedor da cobrança) não conhece a Ally, então o agente que atua dentro do app do cliente segue genérico:

- Thread do WhatsApp (bolhas que respondem pacientes) e **banner clínico da Paula** ("o assistente não responde: encaminhado para a equipe") — inalterados
- Execução de cobrança dentro do app
- Logs do painel: "Assistente priorizou/qualificou", "assistente moveu"
- NBA do app: "🤖 Sugestão do assistente"
- Anatomia do app (desenho/build): "Seu assistente", "Ligando o assistente…"
- Premissa do atendimento: "O assistente agenda, remarca e confirma sozinho"

## Grep site-wide por "ssistente" (fora do JourneyDemo) — decisão por ocorrência

| Arquivo | Ocorrência | Decisão |
|---|---|---|
| `src/app/terms/page.tsx` | "chatbots e assistentes virtuais" | **Mantido** — boilerplate legal; /terms é "inalterado em conteúdo" (message house §8); não é a persona |
| `docs/leads-analytics.md` | "Aprovou a 1ª ação do assistente" | **Mantido** — descreve a ação DO APP que o criador aprova (genérico) |
| DemoBuilder / messages.ts / /o-que-tem | — | Sem ocorrências |

## Doc

`docs/message-house-cliente-final.md`: registrada a decisão (persona pública = Ally; agente do app do cliente segue genérico; gênero "a Ally").

## Verificação

- `tsc --noEmit` verde. **Build não rodado** (dev server do usuário ativo na :3000).
- Browser (dev :3000, HMR): entrada + os 3 cenários — a Ally aparece no chat (crumb, chip "Ally", saudação, "assume o dia a dia", HITL "a Ally espera") e as superfícies seguem genéricas (banner/NBA da Paula "o assistente não responde", thread WhatsApp, logs do painel). Zero erros de console.
- Léxico: sem "chatbot" afirmativo; sem nomes de concorrentes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RxHVLNcnKp8AVif5sEuuh3