### PR TITLE
docs: histórico de implantação e runbooks do site

### DIFF
--- a/docs/historico-implantacao.md
+++ b/docs/historico-implantacao.md
@@ -1,0 +1,68 @@
+# Histórico de implantação — www.fluxomind.com (julho/2026)
+
+Registro do que foi construído, decidido e publicado na virada do site para a
+apresentação ao cliente final. O histórico fino de código está no git; este doc
+registra **decisões e infraestrutura externa** que o git não mostra.
+
+## Decisões de posicionamento
+
+| Decisão | Data | Onde está |
+|---|---|---|
+| Site = melhor apresentação para o **cliente final** ("plataforma hoje + visão de especialistas") | 2026-07-02 | Lei de copy em `docs/message-house-cliente-final.md` |
+| Domínio canônico **www.fluxomind.com** (nunca .com.br) | 2026-07-02 | `metadataBase`, sitemap, JSON-LD |
+| "Entrar"/signup **fora do site** até o lançamento da plataforma | 2026-07-02 | CTAs → demo + form do beta |
+| **Ally é a persona pública** da jornada de criação. O agente dentro do app do cliente final segue "assistente" genérico | 2026-07-03 | PR #27; §persona do message house |
+| Cada cenário da demo gera uma **superfície de app diferente** (kanban / financeiro / chats) — nunca a mesma cara | 2026-07-03 | PR #24; feedback direto do fundador |
+| Léxico vetado na copy pública: nomes de concorrentes, "chatbot" afirmativo, "waitlist", "código morto", "substrato vivo"; "6 dimensões" só em /plataforma | 2026-07-02 | §7 do message house |
+| Copy da /plataforma nunca pode dizer "a cada PR / a cada mudança / continuamente" sobre CI: os workflows automáticos da plataforma estão **pausados desde 2026-04-25** (custo, até o release). O honesto é "sob demanda e no pipeline de deploy" | 2026-07-03 | PR #26 |
+
+## O que foi ao ar (PRs na main)
+
+- **#21–#23** — Site reescrito sob o message house; captura de leads + analytics
+  first-party; `/demo` publicada como edição pública da jornada de criação
+  (protótipo DP087 v2), tela cheia, autopilot ◀ ▶, chat de texto livre, mobile
+  com toggle Conversa ⇄ Seu app; menu hambúrguer; nav em ordem de jornada.
+- **#24** — 3 cenários na demo (leads, fluxo de caixa, atendimento WhatsApp),
+  cada um com superfície própria; botão ↺ Recomeçar; digitação humana emulada
+  (autopilot digita no input; placeholder máquina-de-escrever na entrada).
+- **#25** — SEO técnico: `sitemap.ts` (9 rotas públicas), `robots.ts`
+  (disallow /admin e /api), JSON-LD Organization + WebSite (layout) e FAQPage
+  (home, espelha o FAQ real).
+- **#26** — Fact-check da /plataforma e /seguranca contra o repo real
+  `fluxomind-platform`: ~26 claims confirmados (39 engines, hash-chain, BYOK,
+  pgTAP…), 6 correções de exagero/erro (mapa de camadas, compliance e CI).
+- **#27** — Ally como persona pública da jornada; botões passo a passo com
+  destaque (◀ vermelho, ▶ azul).
+
+## Infraestrutura externa (não versionada)
+
+- **Hosting**: Vercel, projeto `fluxomind-site2`, team `fluxominds-projects`.
+  Deploy automático a cada push na `main`. Domínio `www.fluxomind.com`.
+- **Envs de Production** (Vercel → Settings → Environment Variables):
+  `LEAD_WEBHOOK_URL`, `EVENTS_WEBHOOK_URL`, `ADMIN_TOKEN`. Os valores dos
+  webhooks ficam SÓ lá e no Apps Script — não commitá-los nem colá-los em docs.
+- **Planilha de leads**: "Leads-site" (Drive compartilhado
+  *Marketing and Customer/Leads-Site*, conta fluxomind.com). Recebe cada lead
+  do form via Apps Script Web App (acesso "Qualquer pessoa"). Validada e2e
+  em 2026-07-03.
+- **Planilha de eventos**: "site-pageview" (mesmo Drive). Recebe cada evento de
+  analytics (`pageview`, `demo_*`, `jornada_*`, cliques) via Apps Script
+  próprio. Colunas: data/hora · evento · props · path · sessão · navegador.
+  Configurada e validada e2e em 2026-07-04. **Não** configurar
+  `EVENTS_WEBHOOK_URL` no `.env.local` — testes locais sujariam a planilha.
+- **Google Search Console** (2026-07-03/04): domínio `fluxomind.com`
+  verificado; sitemap `https://www.fluxomind.com/sitemap.xml` submetido —
+  status **Processado**, 9 páginas encontradas.
+- **Vercel CLI** logado na máquina do fundador (conta ralfonunes-5159); a
+  worktree do site está linkada ao projeto (`.vercel/`, git-ignorado), então
+  `vercel env ls/add` e `vercel redeploy` funcionam direto do terminal.
+
+## Pendências conhecidas (com gate)
+
+| Item | Gate / condição |
+|---|---|
+| Prova social (depoimentos, casos) | Dogfood gerar números (BCM-07, ~mês 6) |
+| Signup / "Entrar" no site | Lançamento da plataforma |
+| `/admin/leads` vazio em produção | Limitação serverless documentada; a planilha é a fonte oficial |
+| Rate-limit em memória por instância | Migrar p/ KV/Redis se o tráfego crescer |
+| Fecho da demo no "home do workspace" com os 3 apps lado a lado | Ideia de backlog, sem urgência |

--- a/docs/runbooks.md
+++ b/docs/runbooks.md
@@ -1,0 +1,128 @@
+# Runbooks — operação do site fluxomind.com
+
+Procedimentos de rotina e de incidente. Contexto de decisões:
+`docs/historico-implantacao.md`. Copy: `docs/message-house-cliente-final.md`.
+Analytics/leads em detalhe: `docs/leads-analytics.md`.
+
+## 1. Rodar o site localmente
+
+```bash
+npm run dev            # porta 3000
+npm run dev -- -p 3010 # porta alternativa
+```
+
+- Acesso de outra máquina na mesma rede: `http://<ip-da-máquina>:<porta>`
+  (`ipconfig getifaddr en0` dá o IP; o Next escuta em todas as interfaces).
+- **Nunca** rode `npm run build` com o dev server de pé na mesma pasta — o
+  build corrompe o `.next` em uso. Pare o dev antes, ou builde em outra
+  worktree.
+
+## 2. Publicar uma mudança
+
+1. `git fetch origin && git switch -c <tipo>/<slug> origin/main` — **nunca**
+   commit direto na `main`.
+2. Edite; valide com `npx tsc --noEmit`.
+3. Copy nova? Confira o léxico vetado e o tom no
+   `docs/message-house-cliente-final.md` (§6 CTAs, §7 léxico).
+4. Pare o dev server e rode `npm run build` completo (gate antes do PR).
+5. Push + `gh pr create --base main`. Merge só após aprovação.
+6. O merge na `main` dispara o deploy automático na Vercel (~1–2 min).
+7. Verifique em produção: a página mudada responde e contém a mudança
+   (`curl -s https://www.fluxomind.com/<rota> | grep "<marcador>"`).
+
+## 3. Ver os leads
+
+- **Fonte oficial**: planilha "Leads-site" (Drive *Marketing and
+  Customer/Leads-Site*). Cada linha = um lead do form.
+- Tela interna: `/admin/leads` — em dev, direto; em produção exige
+  `?token=<ADMIN_TOKEN>` e **só mostra a instância atual** (serverless não
+  persiste arquivo). Use a planilha como verdade.
+- Diagnóstico: logs da Vercel com tag `[fm-lead]` (`[fm-lead-hp]` = honeypot).
+
+## 4. Ver o funil (eventos)
+
+- Planilha "site-pageview": cada linha = um evento (`pageview`, `demo_*`,
+  `jornada_*` com prop `cenario`, cliques `data-track`). Taxonomia completa em
+  `docs/leads-analytics.md`.
+- Funil da demo: `pageview(/demo)` → `jornada_start` → `jornada_keep` →
+  `jornada_publish` → `jornada_done` → `jornada_beta_click` →
+  `beta_form_submitted` (este último cai na planilha de leads).
+- Busca orgânica: Google Search Console (propriedade `fluxomind.com`).
+
+## 5. Gerenciar variáveis de ambiente (Vercel)
+
+```bash
+vercel env ls production                       # listar
+printf '<valor>' | vercel env add NOME production
+vercel env rm NOME production
+```
+
+- Env nova/alterada **só vale após redeploy**: runbook 6.
+- Envs atuais de Production: `LEAD_WEBHOOK_URL`, `EVENTS_WEBHOOK_URL`,
+  `ADMIN_TOKEN`. Local (`.env.local`, nunca commitado): `LEAD_WEBHOOK_URL`,
+  `ADMIN_TOKEN` — **sem** `EVENTS_WEBHOOK_URL` (não sujar a planilha em teste).
+
+## 6. Redeploy / rollback
+
+```bash
+vercel ls --prod                 # lista deployments de produção
+vercel redeploy <url-do-deploy>  # rebuilda e realia www.fluxomind.com
+```
+
+- **Rollback** = `vercel redeploy` de um deployment anterior saudável (ou
+  Vercel Dashboard → Deployments → ⋯ → *Promote to Production*).
+- Verificação pós-deploy: `curl -s -o /dev/null -w "%{http_code}"
+  https://www.fluxomind.com/` deve dar 200; teste também a rota alterada.
+
+## 7. Incidente: leads não chegam na planilha
+
+Sintoma típico: form mostra o fallback de e-mail (a API devolve 502 quando o
+webhook falha). O lead **não se perde na hora**: fica no log `[fm-lead]`
+(retenção ~1h–1d — aja rápido).
+
+1. Logs da Vercel → busque `[fm-lead]` → copie os leads do período.
+2. Teste o webhook: POST manual na URL do Apps Script (o `LEAD_WEBHOOK_URL`) —
+   resposta sã é **302 → echo `{"ok":true}`** (siga o `Location`).
+3. Se o Apps Script quebrou: abra a planilha → Extensões → Apps Script →
+   Implantar → **Gerenciar implantações**. Confira "Quem pode acessar" =
+   **"Qualquer pessoa"** (não "…com Conta do Google" — erro clássico:
+   página "Não é possível abrir o arquivo"). Reimplante ("Nova versão"; a URL
+   se mantém).
+4. Se a URL mudou (nova implantação): atualize `LEAD_WEBHOOK_URL` (runbook 5)
+   + redeploy (runbook 6).
+5. Reinsira na planilha os leads capturados no passo 1.
+
+O mesmo procedimento vale para eventos (`EVENTS_WEBHOOK_URL`, tag
+`[fm-event]`), com menos urgência — evento perdido não é lead perdido.
+
+## 8. Incidente: site fora do ar
+
+1. `curl -sI https://www.fluxomind.com/` — 200? 500? timeout?
+2. Vercel Dashboard → Deployments: o último deploy falhou? Veja os build logs.
+3. Deploy quebrado → rollback (runbook 6) e corrija na branch com calma.
+4. Vercel fora do ar (raro): status.vercel.com; só aguardar.
+
+## 9. Editar a demo (/demo)
+
+Tudo vive em `src/components/JourneyDemo.tsx` (arquivo grande — leia por
+seções). Anatomia:
+
+- **Cenários**: objeto `CENARIOS` (leads / caixa / atendimento), cada um com
+  `surface` (`kanban` | `financeiro` | `chats`) e roteamento por regex do texto
+  livre. Novo cenário = nova entrada + nova superfície + pill de entrada.
+- **Autopilot**: array `CHECKPOINTS` (8 passos); ◀ replay determinístico
+  (`resetAll` + `reducedRef`), ▶ avança. Travas: `beginOnce`, `busyRef`,
+  `lockRef`; cancelamento por época via `genRef` (Recomeçar incrementa).
+- **Persona**: Ally fala com o criador; o agente DENTRO do app do cliente é
+  "assistente" genérico. Não misturar (decisão registrada no histórico).
+- Teste manual mínimo após mexer: os 3 cenários ponta a ponta via ▶, um ◀,
+  um ↺ Recomeçar, e mobile 390 px sem overflow horizontal.
+
+## 10. SEO
+
+- Rota nova no site → adicionar em `src/app/sitemap.ts` (e conferir se não é
+  privada; privadas ficam fora e bloqueadas no `robots.ts`).
+- FAQ da home alterado → atualizar o `FAQ_JSONLD` em `src/app/page.tsx`
+  (duplicação consciente; há comentário no código).
+- Indexação: Search Console → Sitemaps (deve constar "Processado") e
+  Indexação → Páginas.


### PR DESCRIPTION
Registro do que foi implantado em jul/2026 (decisões, PRs #21–#27, infra externa: Vercel, planilhas Leads-site e site-pageview, Google Search Console com sitemap processado/9 páginas) + runbooks de operação (local, publicação, leads, funil, envs, redeploy/rollback, incidentes, demo, SEO).

Sem mudança de código — só `docs/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RxHVLNcnKp8AVif5sEuuh3