### PR TITLE
Página de privacidade (LGPD) e documentação essencial do repo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,48 @@
+# Contribuindo com o fluxomind-site
+
+Guia do fluxo de trabalho deste repositório. A `main` publica em produção
+automaticamente — o fluxo existe para nenhuma mudança chegar lá sem revisão
+(ver [ADR-0004](docs/adr/0004-fluxo-branch-pr-deploy-main.md)).
+
+## Fluxo
+
+1. **Crie uma branch** a partir da `main` atualizada:
+   `feat/<slug>`, `fix/<slug>`, `docs/<slug>`, `chore/<slug>` ou `hotfix/<slug>`.
+   Nunca commite direto na `main`, nem para correção de uma linha.
+2. **Desenvolva e valide localmente**:
+
+   ```bash
+   npm install
+   npm run dev     # http://localhost:3000
+   npm run lint
+   npm run build   # o build precisa passar antes do PR
+   ```
+
+3. **Abra um PR para a `main`** com descrição do que muda e por quê. Branches
+   ganham preview deploy na Vercel — use o link do preview na revisão.
+4. **Merge = deploy em produção.** Confira o site publicado após o merge
+   (checklist em [docs/runbooks.md](docs/runbooks.md)).
+
+## Regras de conteúdo (copy)
+
+- O [message house](docs/message-house-cliente-final.md) é lei para copy
+  pública: respeite o léxico vetado e as claims verificadas (fact-check no
+  PR #26). Na dúvida sobre uma claim técnica da plataforma, não afirme.
+- Todo link público usa o domínio canônico `www.fluxomind.com`
+  ([ADR-0003](docs/adr/0003-dominio-canonico-www-fluxomind-com.md)).
+
+## Documentação: o que atualizar junto com o código
+
+| Se a mudança… | Atualize |
+|---|---|
+| Cria/remove evento de analytics ou muda o form de leads | [docs/leads-analytics.md](docs/leads-analytics.md) e, se coletar dado novo, a página `/privacidade` |
+| Toma uma decisão de arquitetura/engenharia | Novo ADR em [docs/adr/](docs/adr/README.md) |
+| Mexe em infraestrutura externa (Vercel, DNS, planilhas, envs) | [docs/historico-implantacao.md](docs/historico-implantacao.md) |
+| Muda procedimento de operação/incidente | [docs/runbooks.md](docs/runbooks.md) |
+| Adiciona rota pública | `src/app/sitemap.ts` |
+
+## Segredos
+
+Valores de env (`LEAD_WEBHOOK_URL`, `EVENTS_WEBHOOK_URL`, `ADMIN_TOKEN`) vivem
+**apenas** na Vercel e no Apps Script. Nunca em commit, doc ou exemplo. Para
+reportar vulnerabilidade, veja [SECURITY.md](SECURITY.md).

--- a/README.md
+++ b/README.md
@@ -1,48 +1,67 @@
-# Fluxomind - Plataforma IA-First
+# Fluxomind — site institucional
 
-Este repositório contém o código-fonte da homepage institucional da **Fluxomind**, uma startup brasileira em fase de incubação que está desenvolvendo uma plataforma IA-First, no-code e baseada em metadados para democratizar o uso da inteligência artificial em empresas de qualquer porte.
+Código-fonte do site **www.fluxomind.com** — a apresentação pública da
+Fluxomind, startup brasileira que está desenvolvendo uma plataforma IA-First,
+no-code e baseada em metadados para democratizar o uso da inteligência
+artificial em empresas de qualquer porte.
 
-## 📦 Stack Tecnológica
+## 📦 Stack
 
-- [Next.js 15 (App Router)](https://nextjs.org)
-- [TypeScript](https://www.typescriptlang.org/)
-- [Tailwind CSS](https://tailwindcss.com/)
-- [Vercel](https://vercel.com) (deploy automático via GitHub)
-- [Cloudflare](https://cloudflare.com) (gerenciamento de domínio e DNS)
-- [GitHub](https://github.com/fluxomind/fluxomind-site) (controle de versão)
+- [Next.js 15 (App Router)](https://nextjs.org) + TypeScript + [Tailwind CSS](https://tailwindcss.com/)
+- [Vercel](https://vercel.com) — hosting e deploy automático via GitHub
+- [Cloudflare](https://cloudflare.com) — domínio e DNS
 
-## 🚀 Desenvolvimento Local
+O porquê das escolhas está nos [ADRs](docs/adr/README.md); a visão de
+componentes em [docs/arquitetura.md](docs/arquitetura.md).
+
+## 🚀 Desenvolvimento local
 
 ```bash
 npm install
-npm run dev
+npm run dev    # http://localhost:3000
+npm run lint
+npm run build
 ```
 
-Abra [http://localhost:3000](http://localhost:3000) no navegador para visualizar o projeto localmente.
+### Estrutura
 
-### Estrutura básica
+- `src/app/` → páginas (App Router): home, `/demo`, `/plataforma`, `/precos`, `/terms`, `/privacidade`…
+- `src/app/api/` → captura de leads (`/api/beta`) e analytics first-party (`/api/event`)
+- `src/components/` → componentes (demo interativa, form do beta, header/footer…)
+- `public/` → imagens e logos
 
-- `app/page.tsx` → Página principal
-- `public/` → Contém imagens SVG e PNG usadas nas seções (ex: hero, about, tech...)
-- `src/components/` → Componentes visuais (opcional/futuro)
-- `vercel.json` → Ignored Build Step configurado para só realizar deploy automático na branch `main`
+## 🔒 Fluxo de mudança e deploy
 
-## 🔒 Deploy controlado via branch
+Toda mudança entra por **feature branch + PR** — nunca commit direto na `main`.
+Merge na `main` = deploy automático em produção na Vercel. Fluxo completo em
+[CONTRIBUTING.md](CONTRIBUTING.md).
 
-- `main`: Branch de produção — qualquer push gera deploy automático na Vercel
-- `dev`: Branch de desenvolvimento — deploy automático **desativado** via Ignored Build Step personalizado
+## 📚 Documentação
+
+| Doc | O que cobre |
+|---|---|
+| [CONTRIBUTING.md](CONTRIBUTING.md) | Fluxo de branch/PR, checks e o que atualizar junto com o código |
+| [SECURITY.md](SECURITY.md) | Como reportar vulnerabilidades |
+| [docs/arquitetura.md](docs/arquitetura.md) | Diagrama e componentes do site |
+| [docs/adr/](docs/adr/README.md) | Decisões de arquitetura (por quê) |
+| [docs/runbooks.md](docs/runbooks.md) | Operação: deploy, incidentes, procedimentos |
+| [docs/historico-implantacao.md](docs/historico-implantacao.md) | Infra externa e histórico de decisões de implantação |
+| [docs/leads-analytics.md](docs/leads-analytics.md) | Captura de leads, taxonomia de eventos, envs |
+| [docs/message-house-cliente-final.md](docs/message-house-cliente-final.md) | Lei de copy do site |
 
 ## 🌐 Links úteis
 
-- [Homepage publicada](https://www.fluxomind.com)
+- [Site publicado](https://www.fluxomind.com)
 - [Vercel Dashboard](https://vercel.com/dashboard)
 - [GitHub Repo](https://github.com/fluxomind/fluxomind-site)
 - [Cloudflare Dashboard](https://dash.cloudflare.com)
 
 ## ✨ Missão da Fluxomind
 
-Democratizar a construção de software com IA para empresas de qualquer tamanho, utilizando tecnologia no-code, metadados e uma arquitetura escalável, segura e eficiente.
+Democratizar a construção de software com IA para empresas de qualquer tamanho,
+utilizando tecnologia no-code, metadados e uma arquitetura escalável, segura e
+eficiente.
 
-## 📄 License
+## 📄 Licença
 
 Este projeto está sob domínio da Fluxomind. Todos os direitos reservados ©.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,26 @@
+# Política de Segurança
+
+## Reportando uma vulnerabilidade
+
+Se você encontrou uma vulnerabilidade no site www.fluxomind.com ou neste
+repositório, reporte de forma privada:
+
+- **E-mail**: contato@fluxomind.com (assunto: `[SECURITY]`)
+- **Não** abra issue ou PR público com detalhes da vulnerabilidade antes da
+  correção.
+
+Inclua, se possível: passos para reproduzir, impacto estimado e URL/rota
+afetada. Respondemos em até 5 dias úteis e mantemos você informado até a
+resolução.
+
+## Escopo
+
+- Site em produção (`www.fluxomind.com`), incluindo as rotas `/api/*`.
+- Especial interesse: qualquer forma de acessar dados de leads sem autorização,
+  bypass do rate-limit/honeypot do form, e exposição de variáveis de ambiente.
+
+## Fora de escopo
+
+- Ataques de negação de serviço (DoS/DDoS) e spam volumétrico.
+- Relatórios de scanners automáticos sem prova de exploração.
+- Engenharia social contra o time.

--- a/docs/adr/0001-stack-nextjs-vercel-cloudflare.md
+++ b/docs/adr/0001-stack-nextjs-vercel-cloudflare.md
@@ -1,0 +1,34 @@
+# ADR-0001: Stack do site: Next.js (App Router) + Vercel + Cloudflare
+
+- **Status**: Aceito
+- **Data**: 2026-01 (registrado retroativamente em 2026-07-04)
+
+## Contexto
+
+O site institucional precisa de iteração rápida por um time mínimo, bom SEO
+(páginas estáticas, metadata, sitemap) e custo próximo de zero até o lançamento
+da plataforma. Não há backend próprio dedicado ao site.
+
+## Decisão
+
+- **Next.js 15 (App Router) + TypeScript + Tailwind CSS** como framework único
+  para páginas e rotas de API.
+- **Vercel** como hosting, com deploy automático a partir do GitHub.
+- **Cloudflare** para gerenciamento de domínio e DNS.
+
+## Consequências
+
+- Deploy contínuo sem pipeline própria; preview deploys por branch de graça.
+- Páginas seguem estáticas, mas as rotas `/api/*` tornam o projeto **serverful**
+  (funções serverless) — ver ADR-0002.
+- Logs de runtime na Vercel são efêmeros (~1h no Hobby, ~1 dia no Pro): log não
+  é armazenamento. Consequência prática documentada em `docs/leads-analytics.md`.
+- Lock-in leve na Vercel: aceitável nesta fase; migrar para Cloud Run/VM é
+  possível se um dia for preciso filesystem persistente (ex.: `/admin/leads`).
+
+## Alternativas consideradas
+
+- **Export estático puro (S3/Pages)**: descartado ao adotar captura de leads
+  first-party (precisa executar funções).
+- **WordPress/site builder**: descartado — o site inclui demo interativa da
+  plataforma, que exige código próprio.

--- a/docs/adr/0002-leads-analytics-first-party.md
+++ b/docs/adr/0002-leads-analytics-first-party.md
@@ -1,0 +1,38 @@
+# ADR-0002: Leads e analytics first-party, sem vendor e sem cookies
+
+- **Status**: Aceito
+- **Data**: 2026-07-02
+
+## Contexto
+
+O site precisa captar leads do programa beta e medir o funil da demo. Vendors de
+analytics (GA4 etc.) trazem cookies → banner de consentimento (LGPD), custo e
+dependência externa — desproporcional para um site em fase de incubação.
+
+## Decisão
+
+Captura própria com dois endpoints (`/api/beta` para leads, `/api/event` para
+eventos), que logam no host e repassam a webhooks configuráveis por env
+(`LEAD_WEBHOOK_URL`, `EVENTS_WEBHOOK_URL` → planilhas via Apps Script).
+**Sem cookies**: identificador de sessão anônimo em `sessionStorage`, eventos sem
+PII. Detalhe operacional completo em `docs/leads-analytics.md`.
+
+## Consequências
+
+- Sem cookies e sem PII nos eventos → **sem banner de consentimento**; a base
+  legal do lead é o consentimento declarado no form (links para `/terms` e
+  `/privacidade`).
+- O site deixa de ser 100% estático (ver ADR-0001); `output: 'export'` deixa de
+  funcionar.
+- `LEAD_WEBHOOK_URL` é **obrigatória de fato** em produção: sem ela, leads só
+  existem nos logs efêmeros do host.
+- Rate-limit em memória, por instância serverless (melhor esforço). Gatilho de
+  revisão: migrar para KV/Redis se o tráfego crescer.
+- Trocar o destino dos dados (Sheets → CRM → PostHog) é trocar uma env, zero
+  código.
+
+## Alternativas consideradas
+
+- **GA4 / vendor de analytics**: descartado — cookies + banner + dependência.
+- **Banco de dados próprio**: descartado nesta fase — planilha via webhook cobre
+  o volume atual sem infraestrutura nova.

--- a/docs/adr/0003-dominio-canonico-www-fluxomind-com.md
+++ b/docs/adr/0003-dominio-canonico-www-fluxomind-com.md
@@ -1,0 +1,25 @@
+# ADR-0003: Domínio canônico único: www.fluxomind.com
+
+- **Status**: Aceito
+- **Data**: 2026-07-02
+
+## Contexto
+
+A marca possui mais de uma variante de domínio (`.com`, `.com.br`, apex vs
+`www`). Variantes indexadas em paralelo dividem autoridade de SEO e criam links
+inconsistentes em materiais públicos.
+
+## Decisão
+
+**`https://www.fluxomind.com`** é o único domínio canônico. Ele é a base de
+`metadataBase`, do `sitemap.ts`, do JSON-LD (Organization/WebSite) e de todo
+link público. Nunca divulgar `.com.br`.
+
+## Consequências
+
+- Google Search Console verificado no domínio `fluxomind.com`; sitemap submetido
+  em `https://www.fluxomind.com/sitemap.xml` (status registrado em
+  `docs/historico-implantacao.md`).
+- Qualquer variante nova de domínio deve redirecionar 301 para o canônico
+  (configuração na Cloudflare/Vercel, fora do repo).
+- Materiais de marketing e copy usam sempre `www.fluxomind.com`.

--- a/docs/adr/0004-fluxo-branch-pr-deploy-main.md
+++ b/docs/adr/0004-fluxo-branch-pr-deploy-main.md
@@ -1,0 +1,25 @@
+# ADR-0004: Fluxo de mudança: branch + PR; deploy automático só na main
+
+- **Status**: Aceito
+- **Data**: 2026-07-02
+
+## Contexto
+
+Todo push na `main` publica em produção na Vercel imediatamente. Sem um fluxo
+disciplinado, um commit direto equivale a um deploy sem revisão.
+
+## Decisão
+
+- Nenhum commit direto na `main` — **toda mudança entra por feature branch + PR**,
+  inclusive hotfix e correção de uma linha.
+- Nomenclatura: `feat/<slug>`, `fix/<slug>`, `docs/<slug>`, `chore/<slug>`,
+  `hotfix/<slug>`.
+- A `main` é a branch de produção: merge do PR = deploy.
+
+## Consequências
+
+- PR é a unidade de revisão e de registro — o histórico da `main` vira um log de
+  releases legível (ver "O que foi ao ar" em `docs/historico-implantacao.md`).
+- Branches abertas ganham preview deploy na Vercel de graça, útil para validar
+  antes do merge.
+- Fluxo operacional detalhado em `CONTRIBUTING.md`.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,28 @@
+# ADRs — Architecture Decision Records
+
+Registro das decisões de arquitetura e engenharia do site. O git mostra *o que*
+mudou; um ADR registra *por que* — contexto, decisão e consequências — para que a
+decisão não viva só na cabeça de quem decidiu.
+
+## Regras
+
+- **Um arquivo por decisão**, numerado: `NNNN-titulo-curto.md` (use [template.md](template.md)).
+- **Append-only**: ADR aceito não se edita. Se a decisão mudar, escreva um novo
+  ADR que **substitui** o antigo e atualize o status do antigo para
+  `Substituído por ADR-NNNN`.
+- Registre decisões que custam caro reverter ou que geram "por que isso é assim?"
+  seis meses depois. Ajuste fino de copy e refactor local não precisam de ADR —
+  decisões de posicionamento/copy vivem no `docs/message-house-cliente-final.md`.
+- Decisões de infraestrutura externa (Vercel, DNS, planilhas) continuam no
+  `docs/historico-implantacao.md`; o ADR referencia, não duplica.
+
+## Índice
+
+| ADR | Título | Status |
+|---|---|---|
+| [0001](0001-stack-nextjs-vercel-cloudflare.md) | Stack do site: Next.js (App Router) + Vercel + Cloudflare | Aceito |
+| [0002](0002-leads-analytics-first-party.md) | Leads e analytics first-party, sem vendor e sem cookies | Aceito |
+| [0003](0003-dominio-canonico-www-fluxomind-com.md) | Domínio canônico único: www.fluxomind.com | Aceito |
+| [0004](0004-fluxo-branch-pr-deploy-main.md) | Fluxo de mudança: branch + PR; deploy automático só na main | Aceito |
+
+Referência sobre o formato: [adr.github.io](https://adr.github.io/).

--- a/docs/adr/template.md
+++ b/docs/adr/template.md
@@ -1,0 +1,22 @@
+# ADR-NNNN: Título curto da decisão
+
+- **Status**: Proposto | Aceito | Substituído por ADR-NNNN
+- **Data**: AAAA-MM-DD
+
+## Contexto
+
+Qual problema ou força motivou a decisão. O que estava em jogo, quais restrições
+(prazo, custo, time, LGPD…) existiam no momento.
+
+## Decisão
+
+O que foi decidido, em uma ou duas frases afirmativas.
+
+## Consequências
+
+O que fica mais fácil, o que fica mais difícil, e quais dívidas/gatilhos de
+revisão a decisão cria (ex.: "revisar quando o tráfego passar de X").
+
+## Alternativas consideradas (opcional)
+
+Opções descartadas e o motivo, em uma linha cada.

--- a/docs/arquitetura.md
+++ b/docs/arquitetura.md
@@ -1,0 +1,54 @@
+# Arquitetura do site
+
+Visão de componentes do www.fluxomind.com. O *porquê* de cada escolha está nos
+[ADRs](adr/README.md); a operação (deploy, incidentes) está em [runbooks.md](runbooks.md).
+
+## Diagrama
+
+```mermaid
+flowchart LR
+  V[Visitante] -->|HTTPS| CF[Cloudflare<br/>DNS www.fluxomind.com]
+  CF --> VC[Vercel<br/>Next.js 15 App Router]
+
+  subgraph VC_APP [Aplicação]
+    P[Páginas estáticas<br/>home, /demo, /plataforma, …]
+    AB["/api/beta<br/>(lead do form)"]
+    AE["/api/event<br/>(analytics first-party)"]
+    AL["/admin/leads<br/>(interna, token)"]
+  end
+
+  VC --> P
+  P -->|form beta| AB
+  P -->|eventos sem cookies| AE
+
+  AB -->|"POST JSON (LEAD_WEBHOOK_URL)"| GS1[Apps Script → planilha Leads-site]
+  AE -->|"POST JSON (EVENTS_WEBHOOK_URL)"| GS2[Apps Script → planilha site-pageview]
+  AB -.->|"log [fm-lead] (efêmero)"| LOGS[Logs Vercel]
+```
+
+## Componentes
+
+| Componente | O que é | Onde |
+|---|---|---|
+| Páginas | Estáticas, geradas no build; SEO em `sitemap.ts`, `robots.ts`, JSON-LD no layout | `src/app/*/page.tsx` |
+| Demo interativa | Jornada de criação (persona Ally), 3 cenários, roda 100% no cliente | `src/components/JourneyDemo.tsx`, `DemoBuilder.tsx` |
+| Captura de leads | Valida, loga e repassa ao webhook; honeypot + rate-limit | `src/app/api/beta/` |
+| Analytics | Eventos first-party sem cookies (taxonomia em [leads-analytics.md](leads-analytics.md)) | `src/app/api/event/`, `src/components/Analytics.tsx` |
+| Admin de leads | Tabela interna noindex; exige `ADMIN_TOKEN`; depende de filesystem persistente (não funciona na Vercel) | `src/app/admin/leads/` |
+| Páginas legais | Termos de Uso e Política de Privacidade (LGPD) | `src/app/terms/`, `src/app/privacidade/` |
+
+## Fluxo dos dados de lead
+
+1. Visitante envia o form do beta → `POST /api/beta`.
+2. A rota valida (e-mail, honeypot, rate-limit 5/h por IP), grava no log
+   (`[fm-lead]`, efêmero) e repassa ao `LEAD_WEBHOOK_URL`.
+3. O Apps Script recebe e grava na planilha **Leads-site** — o destino durável
+   oficial.
+4. Se o webhook falhar: API responde 502 e o form oferece fallback por e-mail;
+   o lead ficou no log como amortecedor.
+
+## Infraestrutura externa
+
+Projeto Vercel, envs de produção, planilhas e Search Console estão registrados em
+[historico-implantacao.md](historico-implantacao.md) — valores de env **nunca**
+entram no repo.

--- a/docs/runbooks.md
+++ b/docs/runbooks.md
@@ -102,7 +102,29 @@ O mesmo procedimento vale para eventos (`EVENTS_WEBHOOK_URL`, tag
 3. Deploy quebrado → rollback (runbook 6) e corrija na branch com calma.
 4. Vercel fora do ar (raro): status.vercel.com; só aguardar.
 
-## 9. Editar a demo (/demo)
+## 9. Incidente: dados pessoais expostos (LGPD)
+
+Vale para qualquer exposição de dados de leads (planilha compartilhada errado,
+webhook vazado, `ADMIN_TOKEN` comprometido, acesso indevido ao Drive).
+
+1. **Contenha**: revogue o acesso (permissão da planilha / rotacione
+   `LEAD_WEBHOOK_URL` no Apps Script / troque `ADMIN_TOKEN` — runbooks 5 e 6).
+2. **Avalie o risco**: quais titulares, quais dados (nome, e-mail, empresa,
+   processo), houve acesso real ou só exposição potencial?
+3. **Prazos** (Res. CD/ANPD nº 15/2024; dobrados para agente de pequeno porte,
+   Res. CD/ANPD nº 2/2022): incidente com **risco ou dano relevante** aos
+   titulares → comunicar **ANPD e titulares em até 6 dias úteis** do
+   conhecimento. Comunicação à ANPD pelo formulário no site da ANPD
+   (Comunicado de Incidente de Segurança — CIS); aos titulares, pelo e-mail do
+   lead.
+4. **Registre sempre**: todo incidente — comunicado ou não — fica registrado
+   por **no mínimo 5 anos** (data, o que aconteceu, dados afetados, avaliação
+   de risco, decisão de comunicar ou não e por quê). Registro no Drive
+   (*Marketing and Customer*), fora do repo.
+5. Dúvidas de titulares chegam por **privacidade@fluxomind.com** — responder
+   acesso/confirmação em até 15 dias (art. 19, LGPD).
+
+## 10. Editar a demo (/demo)
 
 Tudo vive em `src/components/JourneyDemo.tsx` (arquivo grande — leia por
 seções). Anatomia:
@@ -118,7 +140,7 @@ seções). Anatomia:
 - Teste manual mínimo após mexer: os 3 cenários ponta a ponta via ▶, um ◀,
   um ↺ Recomeçar, e mobile 390 px sem overflow horizontal.
 
-## 10. SEO
+## 11. SEO
 
 - Rota nova no site → adicionar em `src/app/sitemap.ts` (e conferir se não é
   privada; privadas ficam fora e bloqueadas no `robots.ts`).

--- a/src/app/privacidade/page.tsx
+++ b/src/app/privacidade/page.tsx
@@ -1,0 +1,252 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+
+export const metadata: Metadata = {
+  title: 'Política de Privacidade',
+  description: 'Política de Privacidade da Fluxomind — como coletamos, usamos e protegemos seus dados pessoais (LGPD)',
+};
+
+export default function PrivacyPolicy() {
+  const currentYear = new Date().getFullYear();
+  const lastUpdated = '04 de Julho de 2026';
+
+  return (
+    <div className="min-h-screen bg-white">
+      {/* Header */}
+      <header className="bg-white shadow-sm border-b border-gray-100">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="flex justify-between items-center py-4">
+            <Link href="/" className="flex items-center">
+              <img src="/logoSVG/logo-light.svg" alt="Fluxomind" className="h-8 w-auto" />
+            </Link>
+            <Link href="/" className="text-gray-600 hover:text-gray-900 transition-colors">
+              Voltar ao início
+            </Link>
+          </div>
+        </div>
+      </header>
+
+      {/* Content */}
+      <main className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+        <article className="prose prose-gray max-w-none">
+          <h1 className="text-3xl md:text-4xl font-bold text-gray-900 mb-4">
+            Política de Privacidade
+          </h1>
+          <p className="text-gray-500 mb-8">
+            Última atualização: {lastUpdated}
+          </p>
+
+          <section className="mb-8">
+            <h2 className="text-2xl font-semibold text-gray-900 mb-4">1. Quem somos</h2>
+            <p className="text-gray-600 mb-4">
+              Esta Política de Privacidade descreve como a FLUXOMIND LTDA, inscrita no CNPJ sob o
+              nº 60.162.547/0001-15, com sede no Brasil (&quot;Fluxomind&quot;, &quot;nós&quot;), trata os dados
+              pessoais coletados através do site www.fluxomind.com (&quot;Site&quot;), na condição de
+              controladora, em conformidade com a Lei Geral de Proteção de Dados Pessoais
+              (Lei nº 13.709/2018 — &quot;LGPD&quot;) e o Marco Civil da Internet (Lei nº 12.965/2014).
+            </p>
+          </section>
+
+          <section className="mb-8">
+            <h2 className="text-2xl font-semibold text-gray-900 mb-4">2. Quais dados coletamos</h2>
+            <p className="text-gray-600 mb-4">
+              Coletamos apenas o mínimo necessário para operar o Site e responder ao seu interesse:
+            </p>
+            <ul className="list-disc pl-6 text-gray-600 space-y-2 mb-4">
+              <li>
+                <strong>Dados que você nos envia:</strong> ao preencher o formulário de interesse
+                no programa beta, coletamos nome, e-mail, empresa e a descrição do processo que
+                você deseja automatizar.
+              </li>
+              <li>
+                <strong>Dados de navegação (anônimos):</strong> registramos eventos de uso do Site
+                (páginas visitadas, cliques e progresso na demonstração interativa) de forma
+                first-party, sem cookies e sem identificação pessoal. Usamos apenas um
+                identificador de sessão aleatório e anônimo, armazenado no sessionStorage do seu
+                navegador, que é apagado automaticamente quando você fecha a aba.
+              </li>
+              <li>
+                <strong>Dados técnicos transitórios:</strong> o endereço IP é utilizado
+                momentaneamente para limitar abusos (rate-limiting) e pode constar nos registros
+                técnicos (logs) da infraestrutura de hospedagem, que são retidos por curto período.
+              </li>
+            </ul>
+          </section>
+
+          <section className="mb-8">
+            <h2 className="text-2xl font-semibold text-gray-900 mb-4">3. Para que usamos e com qual base legal</h2>
+            <ul className="list-disc pl-6 text-gray-600 space-y-2 mb-4">
+              <li>
+                <strong>Responder ao seu interesse no beta:</strong> usamos os dados do formulário
+                para entrar em contato sobre o programa beta e avaliar o seu caso de uso. Base
+                legal: consentimento (art. 7º, I, LGPD) e procedimentos preliminares relacionados a
+                contrato (art. 7º, V, LGPD).
+              </li>
+              <li>
+                <strong>Entender e melhorar o Site:</strong> usamos os eventos anônimos de
+                navegação para medir o funil e melhorar o conteúdo. Base legal: legítimo interesse
+                (art. 7º, IX, LGPD) — sem dados pessoais identificáveis.
+              </li>
+              <li>
+                <strong>Segurança e prevenção de abuso:</strong> usamos dados técnicos para
+                proteger o Site contra fraude e uso indevido. Base legal: legítimo interesse
+                (art. 7º, IX, LGPD).
+              </li>
+            </ul>
+            <p className="text-gray-600">
+              Não vendemos seus dados pessoais nem os utilizamos para publicidade de terceiros.
+            </p>
+          </section>
+
+          <section className="mb-8">
+            <h2 className="text-2xl font-semibold text-gray-900 mb-4">4. Cookies</h2>
+            <p className="text-gray-600 mb-4">
+              O Site <strong>não utiliza cookies</strong> — nem próprios, nem de terceiros, nem
+              para publicidade ou rastreamento. A medição de uso é feita com um identificador
+              anônimo de sessão no sessionStorage do navegador, que não permite identificar você e
+              desaparece ao fechar a aba. Por isso o Site não exibe banner de consentimento de
+              cookies. Se essa prática mudar, esta Política será atualizada e o consentimento será
+              solicitado quando exigido.
+            </p>
+          </section>
+
+          <section className="mb-8">
+            <h2 className="text-2xl font-semibold text-gray-900 mb-4">5. Com quem compartilhamos</h2>
+            <p className="text-gray-600 mb-4">
+              Compartilhamos dados apenas com operadores essenciais à operação do Site:
+            </p>
+            <ul className="list-disc pl-6 text-gray-600 space-y-2 mb-4">
+              <li>
+                <strong>Vercel</strong> — hospedagem do Site e execução das rotas de captura
+                (Estados Unidos);
+              </li>
+              <li>
+                <strong>Google</strong> — armazenamento interno dos leads e eventos em planilhas
+                corporativas com acesso restrito (Google Workspace);
+              </li>
+              <li>
+                <strong>Cloudflare</strong> — gerenciamento de domínio e DNS.
+              </li>
+            </ul>
+            <p className="text-gray-600">
+              Esses provedores podem processar dados fora do Brasil. Nesses casos, a transferência
+              internacional ocorre conforme os arts. 33 e seguintes da LGPD, com base nas garantias
+              contratuais oferecidas por cada provedor. Também poderemos compartilhar dados quando
+              exigido por lei ou ordem de autoridade competente.
+            </p>
+          </section>
+
+          <section className="mb-8">
+            <h2 className="text-2xl font-semibold text-gray-900 mb-4">6. Por quanto tempo guardamos</h2>
+            <ul className="list-disc pl-6 text-gray-600 space-y-2">
+              <li>
+                <strong>Leads do beta:</strong> mantidos enquanto durar o relacionamento sobre o
+                programa beta ou até você solicitar a exclusão;
+              </li>
+              <li>
+                <strong>Registros técnicos (logs):</strong> retidos por curto período pela
+                infraestrutura de hospedagem e descartados automaticamente;
+              </li>
+              <li>
+                <strong>Eventos de navegação:</strong> armazenados de forma anônima, sem vínculo
+                com pessoa identificável.
+              </li>
+            </ul>
+          </section>
+
+          <section className="mb-8">
+            <h2 className="text-2xl font-semibold text-gray-900 mb-4">7. Seus direitos (LGPD)</h2>
+            <p className="text-gray-600 mb-4">
+              Nos termos do art. 18 da LGPD, você pode solicitar a qualquer momento:
+            </p>
+            <ul className="list-disc pl-6 text-gray-600 space-y-2 mb-4">
+              <li>Confirmação da existência de tratamento e acesso aos seus dados</li>
+              <li>Correção de dados incompletos, inexatos ou desatualizados</li>
+              <li>Anonimização, bloqueio ou eliminação de dados desnecessários ou excessivos</li>
+              <li>Portabilidade dos dados a outro fornecedor</li>
+              <li>Eliminação dos dados tratados com base no seu consentimento</li>
+              <li>Informação sobre com quem compartilhamos seus dados</li>
+              <li>Revogação do consentimento</li>
+            </ul>
+            <p className="text-gray-600">
+              Para exercer qualquer desses direitos, escreva para{' '}
+              <a href="mailto:contato@fluxomind.com" className="text-blue-600 hover:underline">
+                contato@fluxomind.com
+              </a>
+              . Responderemos nos prazos previstos na legislação. Você também pode apresentar
+              reclamação à Autoridade Nacional de Proteção de Dados (ANPD).
+            </p>
+          </section>
+
+          <section className="mb-8">
+            <h2 className="text-2xl font-semibold text-gray-900 mb-4">8. Segurança</h2>
+            <p className="text-gray-600">
+              Adotamos medidas técnicas e organizacionais proporcionais ao risco: tráfego
+              criptografado (HTTPS), acesso restrito aos dados de leads, mínimo de dados coletados
+              e proteções contra abuso nos formulários. Nenhum sistema é infalível; em caso de
+              incidente de segurança com risco relevante aos titulares, comunicaremos os afetados e
+              a ANPD conforme a LGPD.
+            </p>
+          </section>
+
+          <section className="mb-8">
+            <h2 className="text-2xl font-semibold text-gray-900 mb-4">9. Crianças e adolescentes</h2>
+            <p className="text-gray-600">
+              O Site é direcionado a empresas e profissionais. Não coletamos intencionalmente dados
+              de menores de 18 anos. Se você acredita que um menor nos forneceu dados pessoais,
+              entre em contato para que sejam removidos.
+            </p>
+          </section>
+
+          <section className="mb-8">
+            <h2 className="text-2xl font-semibold text-gray-900 mb-4">10. Alterações desta Política</h2>
+            <p className="text-gray-600">
+              Podemos atualizar esta Política para refletir mudanças no Site ou na legislação. A
+              data de última atualização no topo desta página indica a versão vigente. Alterações
+              relevantes serão destacadas no Site.
+            </p>
+          </section>
+
+          <section className="mb-8">
+            <h2 className="text-2xl font-semibold text-gray-900 mb-4">11. Contato</h2>
+            <p className="text-gray-600 mb-4">
+              Para dúvidas sobre esta Política ou sobre o tratamento dos seus dados pessoais
+              (encarregado de dados):
+            </p>
+            <div className="bg-gray-50 p-6 rounded-lg">
+              <p className="text-gray-700 font-semibold">FLUXOMIND LTDA</p>
+              <p className="text-gray-600">CNPJ: 60.162.547/0001-15</p>
+              <p className="text-gray-600">E-mail: contato@fluxomind.com</p>
+            </div>
+            <p className="text-gray-600 mt-4">
+              Veja também os nossos{' '}
+              <Link href="/terms" className="text-blue-600 hover:underline">
+                Termos de Uso
+              </Link>
+              .
+            </p>
+          </section>
+        </article>
+      </main>
+
+      {/* Footer */}
+      <footer className="bg-gray-900 text-white py-8">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="flex flex-col md:flex-row justify-between items-center">
+            <Link href="/" className="mb-4 md:mb-0">
+              <img src="/logoSVG/logo-dark.svg" alt="Fluxomind" className="h-8 w-auto" />
+            </Link>
+            <div className="text-center md:text-right">
+              <p className="text-gray-400">
+                &copy; {currentYear} Fluxomind &mdash; Todos os direitos reservados.
+              </p>
+              <p className="text-gray-500 text-sm mt-2">
+                FLUXOMIND LTDA &mdash; CNPJ: 60.162.547/0001-15
+              </p>
+            </div>
+          </div>
+        </div>
+      </footer>
+    </div>
+  );
+}

--- a/src/app/privacidade/page.tsx
+++ b/src/app/privacidade/page.tsx
@@ -40,7 +40,7 @@ export default function PrivacyPolicy() {
             <h2 className="text-2xl font-semibold text-gray-900 mb-4">1. Quem somos</h2>
             <p className="text-gray-600 mb-4">
               Esta Política de Privacidade descreve como a FLUXOMIND LTDA, inscrita no CNPJ sob o
-              nº 60.162.547/0001-15, com sede no Brasil (&quot;Fluxomind&quot;, &quot;nós&quot;), trata os dados
+              nº 60.162.547/0001-15, com sede em São Paulo/SP, Brasil (&quot;Fluxomind&quot;, &quot;nós&quot;), trata os dados
               pessoais coletados através do site www.fluxomind.com (&quot;Site&quot;), na condição de
               controladora, em conformidade com a Lei Geral de Proteção de Dados Pessoais
               (Lei nº 13.709/2018 — &quot;LGPD&quot;) e o Marco Civil da Internet (Lei nº 12.965/2014).
@@ -130,9 +130,11 @@ export default function PrivacyPolicy() {
             </ul>
             <p className="text-gray-600">
               Esses provedores podem processar dados fora do Brasil. Nesses casos, a transferência
-              internacional ocorre conforme os arts. 33 e seguintes da LGPD, com base nas garantias
-              contratuais oferecidas por cada provedor. Também poderemos compartilhar dados quando
-              exigido por lei ou ordem de autoridade competente.
+              internacional ocorre conforme os arts. 33 e seguintes da LGPD e o Regulamento de
+              Transferência Internacional de Dados da ANPD (Resolução CD/ANPD nº 19/2024), com base
+              em cláusulas-padrão contratuais ou outra salvaguarda admitida pela regulamentação.
+              Também poderemos compartilhar dados quando exigido por lei ou ordem de autoridade
+              competente.
             </p>
           </section>
 
@@ -170,8 +172,8 @@ export default function PrivacyPolicy() {
             </ul>
             <p className="text-gray-600">
               Para exercer qualquer desses direitos, escreva para{' '}
-              <a href="mailto:contato@fluxomind.com" className="text-blue-600 hover:underline">
-                contato@fluxomind.com
+              <a href="mailto:privacidade@fluxomind.com" className="text-blue-600 hover:underline">
+                privacidade@fluxomind.com
               </a>
               . Responderemos nos prazos previstos na legislação. Você também pode apresentar
               reclamação à Autoridade Nacional de Proteção de Dados (ANPD).
@@ -210,13 +212,14 @@ export default function PrivacyPolicy() {
           <section className="mb-8">
             <h2 className="text-2xl font-semibold text-gray-900 mb-4">11. Contato</h2>
             <p className="text-gray-600 mb-4">
-              Para dúvidas sobre esta Política ou sobre o tratamento dos seus dados pessoais
-              (encarregado de dados):
+              Para dúvidas sobre esta Política ou para exercer seus direitos, use nosso canal
+              dedicado de comunicação sobre dados pessoais:
             </p>
             <div className="bg-gray-50 p-6 rounded-lg">
               <p className="text-gray-700 font-semibold">FLUXOMIND LTDA</p>
               <p className="text-gray-600">CNPJ: 60.162.547/0001-15</p>
-              <p className="text-gray-600">E-mail: contato@fluxomind.com</p>
+              <p className="text-gray-600">São Paulo/SP — Brasil</p>
+              <p className="text-gray-600">E-mail: privacidade@fluxomind.com</p>
             </div>
             <p className="text-gray-600 mt-4">
               Veja também os nossos{' '}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -15,5 +15,6 @@ export default function sitemap(): MetadataRoute.Sitemap {
     { url: `${BASE_URL}/precos`, changeFrequency: 'monthly', priority: 0.7 },
     { url: `${BASE_URL}/seguranca`, changeFrequency: 'monthly', priority: 0.7 },
     { url: `${BASE_URL}/terms`, changeFrequency: 'yearly', priority: 0.3 },
+    { url: `${BASE_URL}/privacidade`, changeFrequency: 'yearly', priority: 0.3 },
   ];
 }

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -160,9 +160,12 @@ export default function TermsOfService() {
           <section className="mb-8">
             <h2 className="text-2xl font-semibold text-gray-900 mb-4">8. Privacidade e Proteção de Dados</h2>
             <p className="text-gray-600 mb-4">
-              O tratamento de seus dados pessoais é regido pela nossa Política de Privacidade.
-              Ao utilizar os Serviços, você concorda com a coleta e uso de dados conforme descrito
-              na Política de Privacidade.
+              O tratamento de seus dados pessoais é regido pela nossa{' '}
+              <Link href="/privacidade" className="text-blue-600 hover:underline">
+                Política de Privacidade
+              </Link>
+              . Ao utilizar os Serviços, você concorda com a coleta e uso de dados conforme
+              descrito na Política de Privacidade.
             </p>
             <p className="text-gray-600">
               A Fluxomind está comprometida com a conformidade com a Lei Geral de Proteção de Dados (LGPD)

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -46,7 +46,7 @@ export default function TermsOfService() {
             </p>
             <p className="text-gray-600">
               Estes Termos constituem um acordo legal entre você e a FLUXOMIND LTDA, inscrita no
-              CNPJ sob o nº 60.162.547/0001-15, com sede no Brasil (&quot;Fluxomind&quot;, &quot;nós&quot;, &quot;nosso&quot; ou &quot;nossa&quot;).
+              CNPJ sob o nº 60.162.547/0001-15, com sede em São Paulo/SP, Brasil (&quot;Fluxomind&quot;, &quot;nós&quot;, &quot;nosso&quot; ou &quot;nossa&quot;).
             </p>
           </section>
 
@@ -276,6 +276,7 @@ export default function TermsOfService() {
             <div className="bg-gray-50 p-6 rounded-lg">
               <p className="text-gray-700 font-semibold">FLUXOMIND LTDA</p>
               <p className="text-gray-600">CNPJ: 60.162.547/0001-15</p>
+              <p className="text-gray-600">São Paulo/SP — Brasil</p>
               <p className="text-gray-600">E-mail: contato@fluxomind.com</p>
             </div>
           </section>

--- a/src/components/BetaForm.tsx
+++ b/src/components/BetaForm.tsx
@@ -133,8 +133,9 @@ export default function BetaForm() {
       </button>
 
       <p className="bf-legal">
-        Ao enviar, você concorda com os <a href="/terms">Termos de Uso</a> e em ser
-        contatado sobre o beta. Nada de spam.
+        Ao enviar, você concorda com os <a href="/terms">Termos de Uso</a> e a{' '}
+        <a href="/privacidade">Política de Privacidade</a>, e em ser contatado sobre o
+        beta. Nada de spam.
       </p>
     </form>
   );

--- a/src/components/SiteFooter.tsx
+++ b/src/components/SiteFooter.tsx
@@ -24,6 +24,7 @@ export default function SiteFooter({ tagline }: { tagline: string }) {
           <Link href="/por-que">Por quê</Link>
           <Link href="/precos">Preços</Link>
           <Link href="/terms">Termos de Uso</Link>
+          <Link href="/privacidade">Privacidade</Link>
         </div>
         <div className="footmeta">
           <div>{tagline}</div>


### PR DESCRIPTION
## O que muda

### Site
- **Nova página `/privacidade`** — Política de Privacidade (LGPD) fiel às práticas reais: dados do form do beta, analytics first-party sem cookies (sessionStorage anônimo), IP transitório p/ rate-limit, operadores (Vercel/Google/Cloudflare), direitos do art. 18, retenção e contato. Sem cookies → documenta a ausência de banner.
- Links integrados: footer global, consentimento do `BetaForm` (Termos **e** Privacidade), Termos §8 e `sitemap.ts`.

### Documentação do repositório
- `docs/adr/` — README com regras, template e 4 ADRs retroativos: stack Next.js+Vercel+Cloudflare, leads/analytics first-party, domínio canônico www.fluxomind.com, fluxo branch+PR.
- `docs/arquitetura.md` — diagrama Mermaid de componentes e fluxo do lead.
- `CONTRIBUTING.md` — fluxo de branch/PR, checks locais, regras de copy e tabela "se mudar X, atualize doc Y".
- `SECURITY.md` — canal privado de report de vulnerabilidades.
- `README.md` — enxugado, vira índice da documentação; remove referências obsoletas (`vercel.json`, branch `dev`).

## Validação
- `npm run build` ✅ (18 rotas, `/privacidade` estática)
- `npm run lint` ✅ (só warnings de `<img>` pré-existentes no padrão da `/terms`)

## Atenção
- Texto da política segue a LGPD mas **não substitui revisão jurídica** antes de tráfego relevante.
- Contato/encarregado: `contato@fluxomind.com` — trocar se houver endereço dedicado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YHBvrCZKmoPhGav9FesF6g