### PR TITLE
docs: registra PRs #28-#29 e alinha docs com a página de privacidade

### DIFF
--- a/docs/historico-implantacao.md
+++ b/docs/historico-implantacao.md
@@ -33,6 +33,14 @@ registra **decisões e infraestrutura externa** que o git não mostra.
   pgTAP…), 6 correções de exagero/erro (mapa de camadas, compliance e CI).
 - **#27** — Ally como persona pública da jornada; botões passo a passo com
   destaque (◀ vermelho, ▶ azul).
+- **#28** — Este histórico e os runbooks de operação (`docs/runbooks.md`).
+- **#29** — Página `/privacidade` (LGPD) linkada no footer, form do beta,
+  Termos §8 e sitemap; documentação essencial do repo (ADRs em `docs/adr/`,
+  `docs/arquitetura.md`, `CONTRIBUTING.md`, `SECURITY.md`); ajustes da revisão
+  jurídica: canal privacidade@fluxomind.com (sem título "encarregado" —
+  dispensa p/ pequeno porte, Res. CD/ANPD 2/2022), cláusulas-padrão da ANPD na
+  transferência internacional, sede São Paulo/SP, runbook de incidente de
+  dados pessoais (prazos da Res. 15/2024).
 
 ## Infraestrutura externa (não versionada)
 
@@ -66,3 +74,4 @@ registra **decisões e infraestrutura externa** que o git não mostra.
 | `/admin/leads` vazio em produção | Limitação serverless documentada; a planilha é a fonte oficial |
 | Rate-limit em memória por instância | Migrar p/ KV/Redis se o tráfego crescer |
 | Fecho da demo no "home do workspace" com os 3 apps lado a lado | Ideia de backlog, sem urgência |
+| Guarda de logs de acesso por 6 meses (Marco Civil, art. 15) — logs Vercel expiram em ~1h–1d | Decisão de custo/risco (Log Drain). Se ativar: IP retido vira PII → atualizar `/privacidade` e registrar ADR |

--- a/docs/leads-analytics.md
+++ b/docs/leads-analytics.md
@@ -118,5 +118,7 @@ padrão `<projeto>/data/leads.ndjson`).
 
 Sem cookies. Identificador de sessão anônimo em `sessionStorage` (morre com a aba).
 Eventos não carregam PII; o lead carrega os dados que a pessoa digitou, com
-consentimento declarado no form (link para /terms). Se um dia entrar vendor com
-cookies, aí sim revisar consentimento.
+consentimento declarado no form (links para /terms e /privacidade). As práticas
+descritas aqui estão espelhadas na política de privacidade pública
+(`/privacidade`) — **mudou a coleta? Atualize a política junto.** Se um dia
+entrar vendor com cookies, aí sim revisar consentimento.


### PR DESCRIPTION
Ajustes de consistência encontrados na auditoria da documentação:

- **historico-implantacao.md**: o log "O que foi ao ar" parava no #27 — registra #28 (runbooks/histórico) e #29 (privacidade + docs essenciais + revisão jurídica); adiciona a pendência em aberto do Log Drain (Marco Civil art. 15) com gate de decisão.
- **leads-analytics.md**: seção Privacidade citava só /terms — o form linka /terms e /privacidade desde o #29; adiciona a regra "mudou a coleta → atualize a política".

Sem mudança de código; docs apenas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YHBvrCZKmoPhGav9FesF6g