### PR TITLE
Deep-link da demo por cenário (/demo?cenario=...)

### DIFF
--- a/docs/leads-analytics.md
+++ b/docs/leads-analytics.md
@@ -61,7 +61,7 @@ Se o webhook falhar, a API devolve 502 e o form oferece o fallback por e-mail
 | `demo_ops_run` | Visitante iniciou o Ato 2 (operar) | `scenario` |
 | `demo_ops_done` | Ato 2 concluído — o momento de convicção | `scenario` |
 | `demo_beta_click` / `demo_contact_click` | CTA ao fim da demo | — |
-| `jornada_start` | Iniciou a jornada interativa (/demo) | `entry` (planilha \| prosa-livre), `cenario` (leads \| caixa \| atendimento) |
+| `jornada_start` | Iniciou a jornada interativa (/demo) | `entry` (planilha \| prosa-livre \| link), `cenario` (leads \| caixa \| atendimento) |
 | `jornada_stage` | Avançou de etapa na jornada | `stage` (0-7), `label`, `cenario` (leads \| caixa \| atendimento) |
 | `jornada_touch` | Operou o rascunho vivo (1ª interação no app) | — |
 | `jornada_keep` | "Ficar com ele" — aprovou vendo (convicção) | — |
@@ -84,6 +84,10 @@ Se o webhook falhar, a API devolve 502 e o form oferece o fallback por e-mail
 `pageview(/demo)` → `jornada_start` → `jornada_touch` → `jornada_keep` →
 `jornada_hitl_ok` → `jornada_publish` → `jornada_done` → `jornada_beta_click` →
 `beta_form_submitted`.
+
+**Deep-link da demo**: `/demo?cenario=leads|caixa|atendimento` inicia a jornada
+automaticamente naquele cenário com `entry: link` — é como as páginas de caso
+de uso alimentam a demo, e o que separa esse tráfego no funil.
 
 ## Ver os leads
 

--- a/src/components/JourneyDemo.tsx
+++ b/src/components/JourneyDemo.tsx
@@ -659,6 +659,17 @@ export default function JourneyDemo() {
       window.matchMedia('(prefers-reduced-motion: reduce)').matches;
   }, []);
 
+  // Deep-link: /demo?cenario=leads|caixa|atendimento inicia a jornada direto
+  // naquele cenário (entrada das páginas de caso de uso). Lido do window no
+  // cliente — useSearchParams exigiria Suspense sem ganho aqui, pois o valor
+  // só importa uma vez, no mount. Parâmetro inválido/ausente = entrada normal
+  // (pills). beginOnce torna o re-run do StrictMode inócuo.
+  useEffect(() => {
+    const q = new URLSearchParams(window.location.search).get('cenario');
+    if (q === 'leads' || q === 'caixa' || q === 'atendimento') startPlanilha(q, 'link');
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   useEffect(() => {
     const n = scrollRef.current;
     if (n) n.scrollTop = n.scrollHeight;
@@ -804,13 +815,13 @@ export default function JourneyDemo() {
     setStagesK(CENARIOS[id].columns);
   };
 
-  async function startPlanilha(id?: CenarioId) {
+  async function startPlanilha(id?: CenarioId, entry: 'planilha' | 'link' = 'planilha') {
     if (!beginOnce()) return;
     const gen = genRef.current;
     const cid = id ?? cenarioRef.current; // replay usa o cenário preservado
     if (id) aplicarCenario(id);
     const c = CENARIOS[cid];
-    track('jornada_start', { entry: 'planilha', cenario: cid });
+    track('jornada_start', { entry, cenario: cid });
     await typeThenPush(`📎 ${c.xlsx}`);
     if (genRef.current !== gen) return;
     await ally(c.planilhaRead, 900);


### PR DESCRIPTION
## O que muda

PR 1 do plano de casos de uso (GEO/SEO): o elo que permitirá às futuras páginas de caso alimentar a demo.

- `/demo?cenario=leads|caixa|atendimento` inicia a jornada automaticamente naquele cenário.
- `jornada_start` ganha `entry: 'link'` na taxonomia (antes: `planilha` | `prosa-livre`) — separa o tráfego vindo das páginas de caso no funil.
- Parâmetro inválido ou ausente: comportamento atual intacto (entrada com pills).
- Implementação: leitura única de `window.location.search` no mount (client) — mantém a rota estática; `useSearchParams` exigiria Suspense sem ganho. `beginOnce` torna o re-run do StrictMode inócuo.
- `docs/leads-analytics.md` atualizado (taxonomia + nota do deep-link).

## Validação

- `tsc --noEmit`, `npm run build` (18 rotas, /demo estática) e lint ✅
- Verificado no navegador com build de produção:
  - `?cenario=caixa` → auto-start com contas-a-receber.xlsx, superfície financeiro ✅
  - `?cenario=atendimento` → auto-start com pacientes.xlsx, superfície chats ✅
  - sem parâmetro e `?cenario=xyz` → entrada normal com pills ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YHBvrCZKmoPhGav9FesF6g