### PR TITLE
Links de entidade: app operante → /app-operante (home + casos)

### DIFF
--- a/src/app/casos-de-uso/[slug]/page.tsx
+++ b/src/app/casos-de-uso/[slug]/page.tsx
@@ -60,7 +60,21 @@ export default async function CasoDeUsoPage({
           </div>
           <div className="kick" style={{ marginTop: 18 }}>{SIGNATURE}</div>
           <h1 style={{ maxWidth: '26ch' }}>{caso.h1}</h1>
-          <p className="hsub">{caso.definicao}</p>
+          {/* 1ª menção do termo linka a definição canônica (/app-operante) —
+              acoplado ao prefixo padrão das definições em casos.ts */}
+          <p className="hsub">
+            {caso.definicao.startsWith('Um app operante') ? (
+              <>
+                Um{' '}
+                <Link href="/app-operante" style={{ textDecoration: 'underline' }}>
+                  app operante
+                </Link>
+                {caso.definicao.slice('Um app operante'.length)}
+              </>
+            ) : (
+              caso.definicao
+            )}
+          </p>
           <div className="herocta">
             <Link
               className="btn btn-primary"

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -352,7 +352,21 @@ export default function Home() {
                 <span key={n}>{n}</span>
               ))}
             </div>
-            <p className="is">{NEGATION.is}</p>
+            {/* 1ª menção do termo na página linka a definição canônica
+                (/app-operante) — acoplado ao prefixo de NEGATION.is */}
+            <p className="is">
+              {NEGATION.is.startsWith('É um app operante') ? (
+                <>
+                  É um{' '}
+                  <Link href="/app-operante" style={{ textDecoration: 'underline' }}>
+                    app operante
+                  </Link>
+                  {NEGATION.is.slice('É um app operante'.length)}
+                </>
+              ) : (
+                NEGATION.is
+              )}
+            </p>
           </div>
         </div>
       </section>


### PR DESCRIPTION
Primeira menção do termo na home e no hero dos 3 casos linka a definição canônica. Sem mudança de copy — só o embrulho em Link, com fallback se o prefixo canônico mudar. Build e HTML verificados.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YHBvrCZKmoPhGav9FesF6g