### PR TITLE
Site multi-idioma: infra i18n (ADR-0006) + EN (landing, categoria, pricing)

### DIFF
--- a/docs/adr/0006-arquitetura-i18n.md
+++ b/docs/adr/0006-arquitetura-i18n.md
@@ -1,0 +1,64 @@
+# ADR-0006: Arquitetura multi-idioma — árvores paralelas por locale
+
+- **Status**: Aceito
+- **Data**: 2026-07-04
+
+## Contexto
+
+Decisão do fundador (2026-07-04): o site inteiro será multi-idioma — EN e PT
+primeiro, ES no futuro. O site é 100% estático, as URLs pt acabaram de ser
+indexadas (Google + Bing), a copy é "lei" governada por message house
+(um por idioma: `message-house-cliente-final.md` pt, `message-house-en.md`),
+e o conteúdo diverge por idioma de propósito (slugs GEO localizados, termo
+da categoria por idioma, dores/buscas por mercado).
+
+## Decisão
+
+**Árvores de rotas paralelas por locale, sem biblioteca de i18n:**
+
+- **pt-BR permanece na raiz** (`/`, `/precos`, …) — URLs intocadas, zero
+  risco ao SEO recém-construído. É o locale canônico do GTM (BCM-07).
+- **EN vive em `/en/*`** com **slugs localizados** (`/en/pricing`,
+  `/en/self-operating-app`) — cada idioma compete pela sua própria busca.
+- **ES futuro = `/es/*`**, mesmo padrão.
+- Copy EN em módulos dedicados (`src/lib/messages-en.ts`, futuros
+  `*-es.ts`), sob a lei do message house daquele idioma. Componentes de
+  chrome por locale (`SiteHeaderEn`, `SiteFooterEn`).
+- **`hreflang` liga os pares** (`alternates.languages` no metadata das duas
+  pontas); sitemap único lista todos os locales.
+- Sem middleware/detecção automática de idioma: a troca é explícita
+  (link "English"/"Português"). Detecção pode entrar depois sem mudar rotas.
+
+### Ordem de tradução (roadmap)
+
+1. ✅ `/en` (landing) + `/en/self-operating-app` (categoria)
+2. `/en/pricing` → `/en/security` → `/en/platform` → `/en/what-it-does`
+   → `/en/accelerate`
+3. `/en/why` (carta do fundador — exige martelo especial: voz pessoal)
+4. `/en/use-cases` + casos (exige `dor_hook`/`buscas` EN nos packages)
+5. Legais EN (tradução mantendo base LGPD — controladora brasileira)
+6. **Demo EN por último** — maior volume (~2.300 linhas de diálogo) e maior
+   risco de quebra de encantamento; projeto próprio, gateado por decisão.
+
+## Consequências
+
+- Duplicação estrutural entre árvores (aceita conscientemente): mudança de
+  layout numa página pt pede espelho na EN — o custo é visível e local, em
+  vez de escondido em catálogos de strings.
+- Adaptações de mercado são legítimas e registradas no message house do
+  idioma (ex.: "fatura em reais, não em dólar" é dor brasileira; em EN vira
+  o mecanismo "one invoice, models included").
+- Cada PR de copy declara quais locales toca; página EN sem par pt não
+  existe (a lei pt é a fonte).
+
+## Alternativas consideradas
+
+- **next-intl com `[locale]` + `localePrefix: 'as-needed'`**: faz o mesmo
+  roteamento, mas exige mover todas as rotas para `[locale]/`, middleware, e
+  extrair ~2.600 linhas de copy pt para catálogos JSON — reescrita do site
+  para ganhar sincronização de strings que **não queremos** (copy diverge
+  por idioma por decisão). **Gatilho para migrar**: se os idiomas passarem a
+  compartilhar copy 1:1, ou se o número de locales passar de 3, ou se
+  entrar detecção automática de idioma.
+- **Domínio por idioma** (.com/.com.br): viola o ADR-0003 (domínio canônico
+  único).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -25,5 +25,6 @@ decisão não viva só na cabeça de quem decidiu.
 | [0003](0003-dominio-canonico-www-fluxomind-com.md) | Domínio canônico único: www.fluxomind.com | Aceito |
 | [0004](0004-fluxo-branch-pr-deploy-main.md) | Fluxo de mudança: branch + PR; deploy automático só na main | Aceito |
 | [0005](0005-catalogo-casos-de-uso-fonte-e-regras.md) | Catálogo de casos de uso: fonte upstream (plataforma), escopo e regras | Aceito |
+| [0006](0006-arquitetura-i18n.md) | Multi-idioma: árvores paralelas por locale (pt raiz, /en, /es futuro) | Aceito |
 
 Referência sobre o formato: [adr.github.io](https://adr.github.io/).

--- a/docs/fontes-upstream.md
+++ b/docs/fontes-upstream.md
@@ -25,6 +25,8 @@
 | `/precos` | BCM-07 `final/product-packaging.md` §0 (price list App-Store) + `pricing-launch-strategy.md` | Preço/âncora só muda upstream primeiro. |
 | Demos (JourneyDemo/DemoBuilder) — o quê demonstrar | `matrix.md` Ranking B + Anexo (auditoria do lighthouse) | O roteiro canônico das demos do site É o cenário no código + o caso em `casos.ts` — **não** duplicar demo-spec na plataforma; a matrix referencia os cenários daqui. |
 
+| `src/lib/messages-en.ts` + páginas `/en/*` | `docs/message-house-en.md` ← `docs/message-house-cliente-final.md` ← BCM-07 | A lei EN é derivada 1:1 da lei pt — mudou a pt, revisar a EN. Termo da categoria em inglês: **um só, sempre** ("self-operating app", proposta aguardando martelo). Escopo atual: credibilidade (landing + categoria); aquisição EN é projeto futuro gateado. |
+
 ## Crosswalk cenário ↔ use case (estado 2026-07-04)
 
 | Cenário (site) | UCs (catálogo) | App correspondente | Papel |

--- a/docs/leads-analytics.md
+++ b/docs/leads-analytics.md
@@ -83,7 +83,8 @@ Casos de uso: `casos-hub-<slug>` (card do hub), `casos-hub-demo-cta`,
 `home-uso-aprovacoes` | `home-uso-paineis` (→ hub, sem página própria ainda),
 `home-usos-todos` (link "todos os casos"). Página da categoria:
 `app-operante-demo-cta`, `app-operante-beta-cta`. Bloco "O pedido, em
-português": `caso-<slug>-pedido-demo-cta`.
+português": `caso-<slug>-pedido-demo-cta`. Páginas EN: `en-home-demo-cta`,
+`en-home-contact-cta`, `en-soa-demo-cta`, `en-soa-contact-cta`.
 
 **O funil que importa** (BCM: instrumentar tudo):
 `pageview(/)` → `demo_run` → `demo_built` → `demo_ops_run` → `demo_ops_done` →

--- a/docs/leads-analytics.md
+++ b/docs/leads-analytics.md
@@ -84,7 +84,8 @@ Casos de uso: `casos-hub-<slug>` (card do hub), `casos-hub-demo-cta`,
 `home-usos-todos` (link "todos os casos"). Página da categoria:
 `app-operante-demo-cta`, `app-operante-beta-cta`. Bloco "O pedido, em
 português": `caso-<slug>-pedido-demo-cta`. Páginas EN: `en-home-demo-cta`,
-`en-home-contact-cta`, `en-soa-demo-cta`, `en-soa-contact-cta`.
+`en-home-contact-cta`, `en-soa-demo-cta`, `en-soa-contact-cta`,
+`en-pricing-demo-cta`, `en-pricing-contact-cta`.
 
 **O funil que importa** (BCM: instrumentar tudo):
 `pageview(/)` → `demo_run` → `demo_built` → `demo_ops_run` → `demo_ops_done` →

--- a/docs/message-house-en.md
+++ b/docs/message-house-en.md
@@ -1,0 +1,55 @@
+# Message House EN — versão em inglês do site (PROPOSTA)
+
+> **Status: PROPOSTA — aguardando martelo do fundador** (termo da categoria e redações).
+> Derivado 1:1 do `message-house-cliente-final.md` (a lei pt é a fonte; nada nasce aqui).
+> Escopo desta fase: **credibilidade internacional** — landing `/en` + página da categoria.
+> Aquisição orgânica EN (casos, demo, GEO completo) é projeto futuro, gateado por decisão.
+
+## 0. A decisão central: o termo da categoria
+
+| Candidato | Prós | Contras | Veredito |
+|---|---|---|---|
+| **self-operating app** ✅ | Autoexplicativo ("an app that runs itself"); ecoa "se opera sozinho"; **nenhum dono do termo em busca** (verificado 2026-07-04); pergunta GEO natural ("what is a self-operating app?") | Mais longo | **Recomendado** |
+| operating app | Curto; ecoa o wordplay "OS" (Commercial OS) | Colide com "operating system" em busca — impossível de rankear/possuir | Descartado |
+| operant app | Espelho literal de "operante" | "Operant" em inglês evoca condicionamento skinneriano | Descartado |
+| autonomous app | Na moda | Hype de agentes, não-ownable, e superpromete (temos HITL — humano decide) | Descartado |
+
+## 1. Redações canônicas (espelho do message house pt)
+
+- **Assinatura:** *Delegate the task. Get the conclusion — with the proof.*
+- **Promessa:** *An app that solves your problem and runs itself — integrated with what you already use, governed, live in weeks (not a months-long project).*
+- **Propósito:** *For 30 years, companies adapted to their software. We exist to invert that: software that molds itself to your business — and works for it.*
+- **Negação tripla:**
+  - Not a chatbot that just replies.
+  - Not a builder that hands you code to maintain.
+  - Not a months-long IT project.
+  - *It's a self-operating app: it builds itself from your problem, runs the day-to-day — and hands the sensitive calls to a human.*
+- **Definição da categoria (1ª frase, GEO):** *A self-operating app is an app that builds itself from your business problem, runs the day-to-day of the process — and escalates to a human when the case demands it. It's the third category of software, between rigid systems that force the company to adapt and human consulting that doesn't scale: software that molds itself to the business and works for it.*
+
+## 2. As 6 perguntas / as 5 regras
+
+| Face | Question | Gloss |
+|---|---|---|
+| Domain | What does the business keep? | your data and concepts |
+| Experience | What do people see and do? | screens and interaction |
+| Intelligence | What thinks and helps decide? | decisions and next steps |
+| Process | What happens on its own? | the day-to-day that runs without you |
+| Connections | What does it talk to? | WhatsApp, e-mail, API, your systems |
+| Trust | Who can access what? | permissions, isolation and proof |
+
+Trust rules: **Framing** (solves the right problem) · **Coherence** (makes sense end-to-end) · **Fix + undo** (mistakes don't hurt) · **Human takes over** (a person decides the sensitive cases) · **Your data, yours only** (truly isolated).
+
+## 3. Honestidade de fase (igual à pt — nunca visão como fato)
+
+Already real: the platform — 39 engines that materialize and operate real apps, multi-tenant, governed. Next chapter: dogfooding — Fluxomind running its own sales operation inside the product. The vision: a catalog of self-operating apps created by experts — declared as vision, never as fact.
+
+## 4. Léxico EN
+
+**Usar:** self-operating app · runs the day-to-day · conclusion with the proof · governed · molds itself to the business · hands off to a human · live in weeks, not months.
+**Vetado:** mesmos vetos da lei pt (concorrentes nomeados, superlativo sem fonte, promessa financeira, catálogo como fato, "waitlist") + **não traduzir "app operante" de outra forma** — um termo só, sempre.
+
+## 5. Regras desta fase
+
+- A demo permanece em português: toda referência EN usa a moldura *"live interactive demo (in Portuguese)"* — honesto, sem esconder.
+- Páginas legais seguem em pt (controlador brasileiro, LGPD); tradução é fase futura.
+- `hreflang` liga os pares pt↔en; domínio canônico único segue o ADR-0003.

--- a/src/app/app-operante/page.tsx
+++ b/src/app/app-operante/page.tsx
@@ -8,6 +8,10 @@ export const metadata: Metadata = {
   title: 'O que é um app operante? — a categoria explicada',
   description:
     'App operante é um app que se constrói a partir do seu problema, opera o dia a dia do processo — e escala para um humano quando o caso exige. Entenda a categoria: as 6 perguntas, as 5 regras da confiança e a diferença para chatbots e builders.',
+  alternates: {
+    canonical: '/app-operante',
+    languages: { 'pt-BR': '/app-operante', en: '/en/self-operating-app' },
+  },
 };
 
 // Página da categoria — o ativo GEO central: a definição canônica de

--- a/src/app/en/page.tsx
+++ b/src/app/en/page.tsx
@@ -72,8 +72,9 @@ export default function HomeEn() {
         </div>
       </header>
 
-      {/* NEGATION */}
-      <section style={{ paddingTop: 0 }}>
+      {/* NEGATION — primeira seção após o hero: mantém o respiro padrão
+          (sem paddingTop: 0, que colava o card no bloco escuro do hero) */}
+      <section>
         <div className="wrap">
           <div className="fit">
             <div className="kick" style={{ color: 'var(--sky)' }}>

--- a/src/app/en/page.tsx
+++ b/src/app/en/page.tsx
@@ -11,6 +11,8 @@ import {
   CTA_EN,
 } from '@/lib/messages-en';
 import { PLATFORM_CONTACT } from '@/lib/platform';
+import SiteHeaderEn from '@/components/SiteHeaderEn';
+import SiteFooterEn from '@/components/SiteFooterEn';
 
 export const metadata: Metadata = {
   title: 'Fluxomind — self-operating apps for your business',
@@ -27,20 +29,7 @@ export const metadata: Metadata = {
 export default function HomeEn() {
   return (
     <div className="page-ent" lang="en">
-      {/* header mínimo EN — o nav completo é pt; aqui: marca + retorno ao pt */}
-      <header className="bg-white" style={{ borderBottom: '1px solid var(--line)' }}>
-        <div className="wrap" style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '14px 24px' }}>
-          <Link href="/en" aria-label="Fluxomind — English home">
-            <img src="/logoSVG/logo-light.svg" alt="Fluxomind" style={{ height: 30 }} />
-          </Link>
-          <div style={{ display: 'flex', gap: 18, alignItems: 'center' }}>
-            <Link href="/en/self-operating-app">What is a self-operating app?</Link>
-            <Link href="/" lang="pt-BR">
-              Português →
-            </Link>
-          </div>
-        </div>
-      </header>
+      <SiteHeaderEn ptHref="/" />
 
       <header className="hero">
         <div className="wrap">
@@ -171,20 +160,7 @@ export default function HomeEn() {
         </div>
       </section>
 
-      {/* footer mínimo EN */}
-      <footer style={{ borderTop: '1px solid var(--line)', padding: '28px 0', marginTop: 20 }}>
-        <div className="wrap" style={{ display: 'flex', flexWrap: 'wrap', gap: 16, justifyContent: 'space-between', alignItems: 'center' }}>
-          <div style={{ color: 'var(--slate)', fontSize: 14 }}>
-            © 2026 Fluxomind · FLUXOMIND LTDA — CNPJ: 60.162.547/0001-15 · São Paulo, Brazil
-          </div>
-          <div style={{ display: 'flex', gap: 16, fontSize: 14 }}>
-            <Link href="/en/self-operating-app">Self-operating app</Link>
-            <Link href="/terms" lang="pt-BR">Termos de Uso</Link>
-            <Link href="/privacidade" lang="pt-BR">Privacidade</Link>
-            <Link href="/" lang="pt-BR">Português</Link>
-          </div>
-        </div>
-      </footer>
+      <SiteFooterEn />
     </div>
   );
 }

--- a/src/app/en/page.tsx
+++ b/src/app/en/page.tsx
@@ -1,0 +1,190 @@
+import Link from 'next/link';
+import type { Metadata } from 'next';
+import {
+  SIGNATURE_EN,
+  PROMISE_EN,
+  PURPOSE_LINE_EN,
+  NEGATION_EN,
+  FACES_EN,
+  TRUST_RULES_EN,
+  PHASE_EN,
+  CTA_EN,
+} from '@/lib/messages-en';
+import { PLATFORM_CONTACT } from '@/lib/platform';
+
+export const metadata: Metadata = {
+  title: 'Fluxomind — self-operating apps for your business',
+  description:
+    'An app that solves your problem and runs itself — built from what you describe, integrated with what you already use, governed, live in weeks. A human decides the sensitive cases.',
+  alternates: {
+    canonical: '/en',
+    languages: { 'pt-BR': '/', en: '/en' },
+  },
+};
+
+// Landing EN — escopo credibilidade (message-house-en.md, PROPOSTA):
+// condensa a home pt; a demo permanece em português com moldura honesta.
+export default function HomeEn() {
+  return (
+    <div className="page-ent" lang="en">
+      {/* header mínimo EN — o nav completo é pt; aqui: marca + retorno ao pt */}
+      <header className="bg-white" style={{ borderBottom: '1px solid var(--line)' }}>
+        <div className="wrap" style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '14px 24px' }}>
+          <Link href="/en" aria-label="Fluxomind — English home">
+            <img src="/logoSVG/logo-light.svg" alt="Fluxomind" style={{ height: 30 }} />
+          </Link>
+          <div style={{ display: 'flex', gap: 18, alignItems: 'center' }}>
+            <Link href="/en/self-operating-app">What is a self-operating app?</Link>
+            <Link href="/" lang="pt-BR">
+              Português →
+            </Link>
+          </div>
+        </div>
+      </header>
+
+      <header className="hero">
+        <div className="wrap">
+          <div>
+            <span className="pill">Fluxomind · self-operating apps</span>
+          </div>
+          <div className="kick" style={{ marginTop: 18 }}>{SIGNATURE_EN}</div>
+          <h1 style={{ maxWidth: '24ch' }}>
+            An app that solves your problem — <span className="g">and runs itself.</span>
+          </h1>
+          <p className="hsub">
+            {PROMISE_EN} You describe the problem in plain language; the app builds itself —
+            and to change it, you just talk.
+          </p>
+          <div className="herocta">
+            <Link className="btn btn-primary" href="/demo" data-track="en-home-demo-cta">
+              {CTA_EN.demo}
+            </Link>
+            <a className="btn btn-ghost" href={PLATFORM_CONTACT} data-track="en-home-contact-cta">
+              {CTA_EN.contact}
+            </a>
+          </div>
+          <p style={{ marginTop: 10, fontSize: 13.5, color: 'var(--slate)' }}>
+            {CTA_EN.demoNote}
+          </p>
+        </div>
+      </header>
+
+      {/* NEGATION */}
+      <section style={{ paddingTop: 0 }}>
+        <div className="wrap">
+          <div className="fit">
+            <div className="kick" style={{ color: 'var(--sky)' }}>
+              What it is — and what it is not
+            </div>
+            <ul style={{ listStyle: 'none', marginTop: 22, display: 'flex', flexDirection: 'column', gap: 10 }}>
+              {NEGATION_EN.nots.map((n) => (
+                <li key={n} style={{ display: 'flex', gap: 10, alignItems: 'flex-start', color: '#A9AEB8', fontSize: 16 }}>
+                  <span aria-hidden="true" style={{ color: '#e07a5f', fontWeight: 700 }}>✕</span>
+                  {n}
+                </li>
+              ))}
+            </ul>
+            <p style={{ marginTop: 22, fontSize: 19, color: '#fff', fontWeight: 600, maxWidth: '58ch', lineHeight: 1.55 }}>
+              {NEGATION_EN.is}{' '}
+              <Link href="/en/self-operating-app" style={{ textDecoration: 'underline', color: '#fff' }}>
+                What is a self-operating app? →
+              </Link>
+            </p>
+          </div>
+        </div>
+      </section>
+
+      {/* THE 6 QUESTIONS */}
+      <section style={{ paddingTop: 0 }}>
+        <div className="wrap">
+          <div className="center">
+            <div className="kick">The anatomy</div>
+            <h2>The 6 questions every self-operating app answers</h2>
+          </div>
+          <div className="ways">
+            {FACES_EN.map((f) => (
+              <div className="way" key={f.label}>
+                <div className="tagm">{f.label}</div>
+                <h3 style={{ marginTop: 8 }}>{f.q}</h3>
+                <p style={{ marginTop: 6 }}>{f.gloss}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* TRUST */}
+      <section style={{ paddingTop: 0 }}>
+        <div className="wrap">
+          <div className="center">
+            <div className="kick">Trust, by design</div>
+            <h2>The 5 rules that make the operation trustworthy</h2>
+          </div>
+          <div className="ways">
+            {TRUST_RULES_EN.map((r) => (
+              <div className="way" key={r.title}>
+                <h3>{r.title}</h3>
+                <p style={{ marginTop: 6 }}>{r.desc}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* PURPOSE + PHASE HONESTY */}
+      <section style={{ paddingTop: 0 }}>
+        <div className="wrap">
+          <div className="center">
+            <div className="kick">Why we exist</div>
+            <h2 style={{ maxWidth: '30ch', margin: '0 auto' }}>{PURPOSE_LINE_EN}</h2>
+          </div>
+          <div className="honest" style={{ marginTop: 28 }}>
+            <b>Transparency.</b> {PHASE_EN.exists} {PHASE_EN.next} {PHASE_EN.vision} We are in
+            beta: adoption happens closely accompanied by our team — live in weeks, not a
+            months-long project.
+          </div>
+        </div>
+      </section>
+
+      {/* FINAL CTA */}
+      <section style={{ paddingTop: 0 }}>
+        <div className="wrap">
+          <div className="cta-card">
+            <div className="kick" style={{ color: 'var(--sky)' }}>
+              See it live
+            </div>
+            <h2>The best definition is watching one being born</h2>
+            <p className="lead">
+              In the interactive demo, a self-operating app builds itself in front of you —
+              from a spreadsheet to a running process, with you approving what you see.{' '}
+              {CTA_EN.demoNote}.
+            </p>
+            <div className="ctab">
+              <Link className="btn btn-primary" href="/demo" data-track="en-home-demo-cta">
+                {CTA_EN.demo}
+              </Link>
+              <a className="btn btn-ghost" href={PLATFORM_CONTACT} data-track="en-home-contact-cta">
+                {CTA_EN.contact}
+              </a>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* footer mínimo EN */}
+      <footer style={{ borderTop: '1px solid var(--line)', padding: '28px 0', marginTop: 20 }}>
+        <div className="wrap" style={{ display: 'flex', flexWrap: 'wrap', gap: 16, justifyContent: 'space-between', alignItems: 'center' }}>
+          <div style={{ color: 'var(--slate)', fontSize: 14 }}>
+            © 2026 Fluxomind · FLUXOMIND LTDA — CNPJ: 60.162.547/0001-15 · São Paulo, Brazil
+          </div>
+          <div style={{ display: 'flex', gap: 16, fontSize: 14 }}>
+            <Link href="/en/self-operating-app">Self-operating app</Link>
+            <Link href="/terms" lang="pt-BR">Termos de Uso</Link>
+            <Link href="/privacidade" lang="pt-BR">Privacidade</Link>
+            <Link href="/" lang="pt-BR">Português</Link>
+          </div>
+        </div>
+      </footer>
+    </div>
+  );
+}

--- a/src/app/en/page.tsx
+++ b/src/app/en/page.tsx
@@ -26,35 +26,49 @@ export const metadata: Metadata = {
 
 // Landing EN — escopo credibilidade (message-house-en.md, PROPOSTA):
 // condensa a home pt; a demo permanece em português com moldura honesta.
+// Assinatura fatiada como na home pt (head branco, tail azul).
+const SIG_BREAK = SIGNATURE_EN.indexOf('. ') + 1;
+const SIG_HEAD = SIGNATURE_EN.slice(0, SIG_BREAK);
+const SIG_TAIL = SIGNATURE_EN.slice(SIG_BREAK + 1);
+
 export default function HomeEn() {
   return (
     <div className="page-ent" lang="en">
       <SiteHeaderEn ptHref="/" />
 
+      {/* HERO — espelho do hero da home pt: centrado, assinatura como h1
+          (lei §1: assinatura = h1 canônico) */}
       <header className="hero">
-        <div className="wrap">
-          <div>
-            <span className="pill">Fluxomind · self-operating apps</span>
-          </div>
-          <div className="kick" style={{ marginTop: 18 }}>{SIGNATURE_EN}</div>
-          <h1 style={{ maxWidth: '24ch' }}>
-            An app that solves your problem — <span className="g">and runs itself.</span>
+        <div className="wrap" style={{ textAlign: 'center', paddingBottom: 48 }}>
+          <span className="pill">
+            <span className="lz" /> Platform in beta · self-operating apps
+          </span>
+          <h1 style={{ maxWidth: '24ch', margin: '0 auto' }}>
+            {SIG_HEAD} <span className="g">{SIG_TAIL}</span>
           </h1>
-          <p className="hsub">
+          <p className="hsub" style={{ maxWidth: '62ch', margin: '18px auto 0' }}>
             {PROMISE_EN} You describe the problem in plain language; the app builds itself —
             and to change it, you just talk.
           </p>
-          <div className="herocta">
-            <Link className="btn btn-primary" href="/demo" data-track="en-home-demo-cta">
+          <div className="herocta" style={{ justifyContent: 'center' }}>
+            <Link className="btn btn-primary btn-lg" href="/demo" data-track="en-home-demo-cta">
               {CTA_EN.demo}
             </Link>
-            <a className="btn btn-ghost" href={PLATFORM_CONTACT} data-track="en-home-contact-cta">
+            <a className="btn btn-ghost btn-lg" href={PLATFORM_CONTACT} data-track="en-home-contact-cta">
               {CTA_EN.contact}
             </a>
           </div>
-          <p style={{ marginTop: 10, fontSize: 13.5, color: 'var(--slate)' }}>
-            {CTA_EN.demoNote}
-          </p>
+          <div className="reassure" style={{ justifyContent: 'center' }}>
+            <span>
+              <b>✓</b> Watch without signing up
+            </span>
+            <span>
+              <b>✓</b> Proof on screen, every step
+            </span>
+            <span>
+              <b>✓</b> {CTA_EN.demoNote}
+            </span>
+          </div>
         </div>
       </header>
 

--- a/src/app/en/pricing/page.tsx
+++ b/src/app/en/pricing/page.tsx
@@ -1,0 +1,198 @@
+import Link from 'next/link';
+import type { Metadata } from 'next';
+import SiteHeaderEn from '@/components/SiteHeaderEn';
+import SiteFooterEn from '@/components/SiteFooterEn';
+import { CTA_EN } from '@/lib/messages-en';
+import { PLATFORM_CONTACT } from '@/lib/platform';
+
+export const metadata: Metadata = {
+  title: 'Pricing',
+  description:
+    'During the beta, access is accompanied and card-free — you join through the beta list. Afterwards, subscription + usage with frontier AI models included: one invoice, no AI provider accounts or keys to manage.',
+  alternates: {
+    canonical: '/en/pricing',
+    languages: { 'pt-BR': '/precos', en: '/en/pricing' },
+  },
+};
+
+// Espelho EN de /precos (ADR-0006). Adaptação registrada no message house EN:
+// a dor "fatura em reais, não em dólar" é brasileira — em EN vira o mecanismo
+// ("one invoice, models included").
+export default function PricingEn() {
+  return (
+    <div className="page-pricing" lang="en">
+      <SiteHeaderEn ptHref="/precos" />
+
+      <header className="hero">
+        <div className="wrap">
+          <div className="center">
+            <div className="kick" style={{ color: 'var(--sky)' }}>
+              Pricing
+            </div>
+            <h1>
+              In beta: no card. <span className="g">After: subscription + usage.</span>
+            </h1>
+            <p className="hsub" style={{ margin: '18px auto 0', maxWidth: '56ch' }}>
+              During the beta, access is accompanied — our team joins you, with no card and no
+              charges. Afterwards, the design is simple: a subscription plus usage, with frontier
+              AI models already included in a single invoice.
+            </p>
+          </div>
+        </div>
+      </header>
+
+      <section>
+        <div className="wrap">
+          <div className="plans">
+            <div className="plan">
+              <div className="ptag">Today · beta</div>
+              <h3>Accompanied beta</h3>
+              <div className="price">
+                <b>No card</b>
+                no cost during the beta
+              </div>
+              <p className="desc">
+                You don&apos;t go in alone: the team accompanies you and builds your first
+                self-operating app with you.
+              </p>
+              <ul>
+                <li><span className="ck">✓</span> Access through the beta list, accompanied by the team</li>
+                <li><span className="ck">✓</span> No card and no charges for the duration of the beta</li>
+                <li><span className="ck">✓</span> A real self-operating app, on your process</li>
+                <li><span className="ck">✓</span> Your data isolated from day one</li>
+              </ul>
+              <a className="btn btn-primary" href={PLATFORM_CONTACT} data-track="en-pricing-contact-cta">
+                {CTA_EN.contact}
+              </a>
+            </div>
+
+            <div className="plan featured">
+              <div className="ribbon">After the beta</div>
+              <div className="ptag">Subscription + usage</div>
+              <h3>One invoice</h3>
+              <div className="price">
+                <b>Subscription + usage</b>
+                with the AI models included
+              </div>
+              <p className="desc">
+                The product design for after the beta: predictable at the base, proportional to
+                what runs.
+              </p>
+              <ul>
+                <li><span className="ck">✓</span> Frontier models built in — no separate AI provider to hire</li>
+                <li><span className="ck">✓</span> A single invoice — no surprise AI bills on the side</li>
+                <li><span className="ck">✓</span> No provider accounts, keys or limits to manage</li>
+                <li><span className="ck">✓</span> Usage visible in your account; to expand, talk to the team</li>
+              </ul>
+              <a className="btn btn-primary" href={PLATFORM_CONTACT} data-track="en-pricing-contact-cta">
+                {CTA_EN.contact}
+              </a>
+            </div>
+
+            <div className="plan">
+              <div className="ptag">Scale</div>
+              <h3>Adoption at scale</h3>
+              <div className="price">
+                <b>With the team</b>
+                tailored terms for scale
+              </div>
+              <p className="desc">
+                To adopt across more processes and more areas — with what your procurement
+                requires.
+              </p>
+              <ul>
+                <li><span className="ck">✓</span> Dedicated isolation and BYOK (your key)</li>
+                <li><span className="ck">✓</span> Governance and a verifiable audit trail</li>
+                <li><span className="ck">✓</span> Guided onboarding, side by side with the team</li>
+                <li><span className="ck">✓</span> A person decides the sensitive cases</li>
+              </ul>
+              <a className="btn btn-ghost-d" href={PLATFORM_CONTACT}>
+                {CTA_EN.contact}
+              </a>
+            </div>
+          </div>
+
+          <div className="honest" style={{ maxWidth: 760, margin: '34px auto 0' }}>
+            <b>Transparency:</b> final price ranges are being defined with the first beta
+            customers — which is why we don&apos;t publish numbers that may still change. What is
+            already defined is the design: <strong>subscription + usage</strong>, with frontier
+            models included in a single invoice.
+          </div>
+        </div>
+      </section>
+
+      <section style={{ paddingTop: 0 }}>
+        <div className="wrap">
+          <div className="faq">
+            <div className="qa">
+              <h4>Do I need a card to start?</h4>
+              <p>
+                No. During the beta there are no charges and no card. You request access and go
+                in accompanied — the team builds your first self-operating app with you.
+              </p>
+            </div>
+            <div className="qa">
+              <h4>How much will it cost after the beta?</h4>
+              <p>
+                Final ranges are being defined with the first customers — we prefer not to
+                publish a number that may still change. The design is settled: subscription +
+                usage, with frontier models included in a single invoice.
+              </p>
+            </div>
+            <div className="qa">
+              <h4>Do I need to hire an AI provider separately?</h4>
+              <p>
+                No. Frontier models come built into the platform: it handles the accounts, the
+                keys and the limits — you get one invoice.
+              </p>
+            </div>
+            <div className="qa">
+              <h4>How do I control how much I spend?</h4>
+              <p>
+                You track usage in your account, and nothing changes tier on its own: to expand
+                capacity, you talk to the team.
+              </p>
+            </div>
+            <div className="qa">
+              <h4>Can I cancel anytime?</h4>
+              <p>
+                Yes. The beta has no cost and no commitment. Afterwards the model is a
+                subscription — you are not locked into a months-long project.
+              </p>
+            </div>
+            <div className="qa">
+              <h4>We are a larger company — how does adoption work?</h4>
+              <p>
+                With the team at your side: dedicated isolation, governance and guided
+                onboarding. <a href={PLATFORM_CONTACT}>Talk to the team</a>.
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="offer" style={{ borderRadius: 0 }}>
+        <div className="wrap">
+          <div className="kick" style={{ color: 'var(--sky)' }}>
+            Start now
+          </div>
+          <h2>See a self-operating app being born</h2>
+          <p className="lead">
+            From a described problem to a running app — in the interactive demo, you operate it
+            yourself. {CTA_EN.demoNote}.
+          </p>
+          <div className="offerbtns">
+            <Link className="btn btn-primary btn-lg" href="/demo" data-track="en-pricing-demo-cta">
+              {CTA_EN.demo}
+            </Link>
+            <a className="btn btn-ghost btn-lg" href={PLATFORM_CONTACT}>
+              {CTA_EN.contact}
+            </a>
+          </div>
+        </div>
+      </section>
+
+      <SiteFooterEn />
+    </div>
+  );
+}

--- a/src/app/en/self-operating-app/page.tsx
+++ b/src/app/en/self-operating-app/page.tsx
@@ -11,6 +11,8 @@ import {
 } from '@/lib/messages-en';
 import { DEFINITION_EN } from '@/lib/messages-en';
 import { PLATFORM_CONTACT } from '@/lib/platform';
+import SiteHeaderEn from '@/components/SiteHeaderEn';
+import SiteFooterEn from '@/components/SiteFooterEn';
 
 export const metadata: Metadata = {
   title: 'What is a self-operating app? — the category, explained',
@@ -79,18 +81,7 @@ export default function SelfOperatingApp() {
         dangerouslySetInnerHTML={{ __html: JSON.stringify(TERM_JSONLD) }}
       />
 
-      <header className="bg-white" style={{ borderBottom: '1px solid var(--line)' }}>
-        <div className="wrap" style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '14px 24px' }}>
-          <Link href="/en" aria-label="Fluxomind — English home">
-            <img src="/logoSVG/logo-light.svg" alt="Fluxomind" style={{ height: 30 }} />
-          </Link>
-          <div style={{ display: 'flex', gap: 18, alignItems: 'center' }}>
-            <Link href="/app-operante" lang="pt-BR">
-              Português →
-            </Link>
-          </div>
-        </div>
-      </header>
+      <SiteHeaderEn ptHref="/app-operante" />
 
       <header className="hero">
         <div className="wrap">
@@ -212,18 +203,7 @@ export default function SelfOperatingApp() {
         </div>
       </section>
 
-      <footer style={{ borderTop: '1px solid var(--line)', padding: '28px 0', marginTop: 20 }}>
-        <div className="wrap" style={{ display: 'flex', flexWrap: 'wrap', gap: 16, justifyContent: 'space-between', alignItems: 'center' }}>
-          <div style={{ color: 'var(--slate)', fontSize: 14 }}>
-            © 2026 Fluxomind · FLUXOMIND LTDA — CNPJ: 60.162.547/0001-15 · São Paulo, Brazil
-          </div>
-          <div style={{ display: 'flex', gap: 16, fontSize: 14 }}>
-            <Link href="/en">English home</Link>
-            <Link href="/terms" lang="pt-BR">Termos de Uso</Link>
-            <Link href="/privacidade" lang="pt-BR">Privacidade</Link>
-          </div>
-        </div>
-      </footer>
+      <SiteFooterEn />
     </div>
   );
 }

--- a/src/app/en/self-operating-app/page.tsx
+++ b/src/app/en/self-operating-app/page.tsx
@@ -1,0 +1,229 @@
+import Link from 'next/link';
+import type { Metadata } from 'next';
+import {
+  SIGNATURE_EN,
+  PURPOSE_LINE_EN,
+  NEGATION_EN,
+  FACES_EN,
+  TRUST_RULES_EN,
+  PHASE_EN,
+  CTA_EN,
+} from '@/lib/messages-en';
+import { DEFINITION_EN } from '@/lib/messages-en';
+import { PLATFORM_CONTACT } from '@/lib/platform';
+
+export const metadata: Metadata = {
+  title: 'What is a self-operating app? — the category, explained',
+  description:
+    'A self-operating app builds itself from your business problem, runs the day-to-day of the process — and escalates to a human when the case demands it. The definition, the 6 questions, the 5 trust rules, and how it differs from chatbots and builders.',
+  alternates: {
+    canonical: '/en/self-operating-app',
+    languages: { 'pt-BR': '/app-operante', en: '/en/self-operating-app' },
+  },
+};
+
+// English category page — mirror of /app-operante under message-house-en.md
+// (PROPOSTA). Same GEO format: definition-first, FAQPage + DefinedTerm JSON-LD.
+
+const FAQ_EN = [
+  { q: 'What is a self-operating app?', a: DEFINITION_EN },
+  {
+    q: 'Is it a chatbot?',
+    a: 'Not a chatbot that just replies. A self-operating app understands the request and resolves it — it runs the process, records it and shows the proof. The conversation is the means; the resolved process is the end.',
+  },
+  {
+    q: 'How is it different from a code builder or generic no-code?',
+    a: 'Building got easy — any AI hands you a prototype. Builders stop there: you get code or screens to maintain and operate on your own. A self-operating app delivers the process running: it operates the day-to-day, evolves through conversation, and hands the sensitive calls to a human.',
+  },
+  {
+    q: 'Do I need to know how to code?',
+    a: 'No. You describe the problem in plain language; the app builds itself — and to change it, you talk.',
+  },
+  {
+    q: 'What does "runs itself" mean?',
+    a: 'The day-to-day of the process — tracking, preparing, executing the routine — runs without anyone having to remember it. Nothing critical goes out without your OK, and every conclusion arrives with the proof of what was done.',
+  },
+  {
+    q: 'Is this real today, or a vision?',
+    a: 'The platform is real — 39 engines that materialize and operate real apps, multi-tenant, governed. We are in beta: adoption happens closely accompanied by our team, live in weeks, not a months-long project.',
+  },
+];
+
+const FAQ_JSONLD = {
+  '@context': 'https://schema.org',
+  '@type': 'FAQPage',
+  mainEntity: FAQ_EN.map((f) => ({
+    '@type': 'Question',
+    name: f.q,
+    acceptedAnswer: { '@type': 'Answer', text: f.a },
+  })),
+};
+
+const TERM_JSONLD = {
+  '@context': 'https://schema.org',
+  '@type': 'DefinedTerm',
+  name: 'self-operating app',
+  description: DEFINITION_EN,
+  url: 'https://www.fluxomind.com/en/self-operating-app',
+};
+
+export default function SelfOperatingApp() {
+  return (
+    <div className="page-ent" lang="en">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(FAQ_JSONLD) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(TERM_JSONLD) }}
+      />
+
+      <header className="bg-white" style={{ borderBottom: '1px solid var(--line)' }}>
+        <div className="wrap" style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '14px 24px' }}>
+          <Link href="/en" aria-label="Fluxomind — English home">
+            <img src="/logoSVG/logo-light.svg" alt="Fluxomind" style={{ height: 30 }} />
+          </Link>
+          <div style={{ display: 'flex', gap: 18, alignItems: 'center' }}>
+            <Link href="/app-operante" lang="pt-BR">
+              Português →
+            </Link>
+          </div>
+        </div>
+      </header>
+
+      <header className="hero">
+        <div className="wrap">
+          <div>
+            <span className="pill">self-operating app · the category</span>
+          </div>
+          <div className="kick" style={{ marginTop: 18 }}>{SIGNATURE_EN}</div>
+          <h1 style={{ maxWidth: '22ch' }}>What is a self-operating app?</h1>
+          <p className="hsub">{DEFINITION_EN}</p>
+          <div className="herocta">
+            <Link className="btn btn-primary" href="/demo" data-track="en-soa-demo-cta">
+              {CTA_EN.demo}
+            </Link>
+            <a className="btn btn-ghost" href={PLATFORM_CONTACT} data-track="en-soa-contact-cta">
+              {CTA_EN.contact}
+            </a>
+          </div>
+          <p style={{ marginTop: 10, fontSize: 13.5, color: 'var(--slate)' }}>
+            {CTA_EN.demoNote}
+          </p>
+        </div>
+      </header>
+
+      <section style={{ paddingTop: 0 }}>
+        <div className="wrap">
+          <div className="center">
+            <div className="kick">Why the category exists</div>
+            <h2 style={{ maxWidth: '30ch', margin: '0 auto' }}>{PURPOSE_LINE_EN}</h2>
+            <p className="lead" style={{ marginTop: 14, maxWidth: '62ch', marginLeft: 'auto', marginRight: 'auto' }}>
+              Building got easy — any AI hands you a prototype. <strong>Operating is what&apos;s
+              missing</strong>, and it is exactly what a self-operating app delivers.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <section style={{ paddingTop: 0 }}>
+        <div className="wrap">
+          <div className="fit">
+            <div className="kick" style={{ color: 'var(--sky)' }}>
+              What it is not
+            </div>
+            <ul style={{ listStyle: 'none', marginTop: 22, display: 'flex', flexDirection: 'column', gap: 10 }}>
+              {NEGATION_EN.nots.map((n) => (
+                <li key={n} style={{ display: 'flex', gap: 10, alignItems: 'flex-start', color: '#A9AEB8', fontSize: 16 }}>
+                  <span aria-hidden="true" style={{ color: '#e07a5f', fontWeight: 700 }}>✕</span>
+                  {n}
+                </li>
+              ))}
+            </ul>
+            <p style={{ marginTop: 22, fontSize: 19, color: '#fff', fontWeight: 600, maxWidth: '58ch', lineHeight: 1.55 }}>
+              {NEGATION_EN.is}
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <section style={{ paddingTop: 0 }}>
+        <div className="wrap">
+          <div className="center">
+            <div className="kick">The anatomy</div>
+            <h2>The 6 questions every self-operating app answers</h2>
+          </div>
+          <div className="ways">
+            {FACES_EN.map((f) => (
+              <div className="way" key={f.label}>
+                <div className="tagm">{f.label}</div>
+                <h3 style={{ marginTop: 8 }}>{f.q}</h3>
+                <p style={{ marginTop: 6 }}>{f.gloss}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section style={{ paddingTop: 0 }}>
+        <div className="wrap">
+          <div className="center">
+            <div className="kick">Trust, by design</div>
+            <h2>The 5 rules that make the operation trustworthy</h2>
+          </div>
+          <div className="ways">
+            {TRUST_RULES_EN.map((r) => (
+              <div className="way" key={r.title}>
+                <h3>{r.title}</h3>
+                <p style={{ marginTop: 6 }}>{r.desc}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section id="faq" style={{ paddingTop: 0 }}>
+        <div className="wrap">
+          <div className="center">
+            <div className="kick">Common questions</div>
+            <h2>What people ask about the category</h2>
+          </div>
+          <div className="faq">
+            {FAQ_EN.map((f) => (
+              <div className="qa" key={f.q}>
+                <h4>{f.q}</h4>
+                <p>{f.a}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section style={{ paddingTop: 0 }}>
+        <div className="wrap">
+          <div className="honest">
+            <b>Transparency.</b> {PHASE_EN.exists} {PHASE_EN.next} {PHASE_EN.vision}
+          </div>
+          <p style={{ textAlign: 'center', marginTop: 14, fontSize: 13.5, color: 'var(--slate)' }}>
+            Updated July 2026 · <Link href="/en">Fluxomind in English</Link> ·{' '}
+            <Link href="/app-operante" lang="pt-BR">versão em português</Link>
+          </p>
+        </div>
+      </section>
+
+      <footer style={{ borderTop: '1px solid var(--line)', padding: '28px 0', marginTop: 20 }}>
+        <div className="wrap" style={{ display: 'flex', flexWrap: 'wrap', gap: 16, justifyContent: 'space-between', alignItems: 'center' }}>
+          <div style={{ color: 'var(--slate)', fontSize: 14 }}>
+            © 2026 Fluxomind · FLUXOMIND LTDA — CNPJ: 60.162.547/0001-15 · São Paulo, Brazil
+          </div>
+          <div style={{ display: 'flex', gap: 16, fontSize: 14 }}>
+            <Link href="/en">English home</Link>
+            <Link href="/terms" lang="pt-BR">Termos de Uso</Link>
+            <Link href="/privacidade" lang="pt-BR">Privacidade</Link>
+          </div>
+        </div>
+      </footer>
+    </div>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -21,6 +21,10 @@ export const metadata: Metadata = {
   title: { absolute: 'Fluxomind — delegue a tarefa, receba a conclusão com a prova' },
   description:
     'Um app que resolve o seu problema e se opera sozinho — integrado ao que você já tem, governado, em semanas. Veja a demonstração: o app se constrói na sua frente e opera o dia a dia, com humano nos casos sensíveis.',
+  alternates: {
+    canonical: '/',
+    languages: { 'pt-BR': '/', en: '/en' },
+  },
 };
 
 // Assinatura canônica (messages.ts), com destaque visual na segunda frase.

--- a/src/app/precos/page.tsx
+++ b/src/app/precos/page.tsx
@@ -9,6 +9,10 @@ export const metadata: Metadata = {
   title: 'Preços',
   description:
     'Durante o beta, o acesso é acompanhado e sem cartão — você entra pela lista do beta. Depois, assinatura + uso com os modelos de fronteira inclusos: uma fatura, em reais, sem gerir contas e chaves de IA.',
+  alternates: {
+    canonical: '/precos',
+    languages: { 'pt-BR': '/precos', en: '/en/pricing' },
+  },
 };
 
 export default function Precos() {

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -21,6 +21,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
     { url: `${BASE_URL}/seguranca`, changeFrequency: 'monthly', priority: 0.7 },
     { url: `${BASE_URL}/en`, changeFrequency: 'monthly', priority: 0.6 },
     { url: `${BASE_URL}/en/self-operating-app`, changeFrequency: 'monthly', priority: 0.6 },
+    { url: `${BASE_URL}/en/pricing`, changeFrequency: 'monthly', priority: 0.5 },
     { url: `${BASE_URL}/terms`, changeFrequency: 'yearly', priority: 0.3 },
     { url: `${BASE_URL}/privacidade`, changeFrequency: 'yearly', priority: 0.3 },
   ];

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -19,6 +19,8 @@ export default function sitemap(): MetadataRoute.Sitemap {
     { url: `${BASE_URL}/por-que`, changeFrequency: 'monthly', priority: 0.7 },
     { url: `${BASE_URL}/precos`, changeFrequency: 'monthly', priority: 0.7 },
     { url: `${BASE_URL}/seguranca`, changeFrequency: 'monthly', priority: 0.7 },
+    { url: `${BASE_URL}/en`, changeFrequency: 'monthly', priority: 0.6 },
+    { url: `${BASE_URL}/en/self-operating-app`, changeFrequency: 'monthly', priority: 0.6 },
     { url: `${BASE_URL}/terms`, changeFrequency: 'yearly', priority: 0.3 },
     { url: `${BASE_URL}/privacidade`, changeFrequency: 'yearly', priority: 0.3 },
   ];

--- a/src/components/SiteFooter.tsx
+++ b/src/components/SiteFooter.tsx
@@ -27,6 +27,7 @@ export default function SiteFooter({ tagline }: { tagline: string }) {
           <Link href="/app-operante">O que é um app operante</Link>
           <Link href="/terms">Termos de Uso</Link>
           <Link href="/privacidade">Privacidade</Link>
+          <Link href="/en" lang="en">English</Link>
         </div>
         <div className="footmeta">
           <div>{tagline}</div>

--- a/src/components/SiteFooterEn.tsx
+++ b/src/components/SiteFooterEn.tsx
@@ -1,0 +1,26 @@
+import Link from 'next/link';
+
+// Rodapé EN — espelho mínimo do SiteFooter pt (ADR-0006). Legais seguem em
+// pt até a fase 5 do roadmap de tradução.
+export default function SiteFooterEn() {
+  return (
+    <footer style={{ borderTop: '1px solid var(--line)', padding: '28px 0', marginTop: 20 }}>
+      <div
+        className="wrap"
+        style={{ display: 'flex', flexWrap: 'wrap', gap: 16, justifyContent: 'space-between', alignItems: 'center' }}
+      >
+        <div style={{ color: 'var(--slate)', fontSize: 14 }}>
+          © 2026 Fluxomind · FLUXOMIND LTDA — CNPJ: 60.162.547/0001-15 · São Paulo, Brazil
+        </div>
+        <div style={{ display: 'flex', flexWrap: 'wrap', gap: 16, fontSize: 14 }}>
+          <Link href="/en">English home</Link>
+          <Link href="/en/self-operating-app">Self-operating app</Link>
+          <Link href="/en/pricing">Pricing</Link>
+          <Link href="/terms" lang="pt-BR">Termos de Uso</Link>
+          <Link href="/privacidade" lang="pt-BR">Privacidade</Link>
+          <Link href="/" lang="pt-BR">Português</Link>
+        </div>
+      </div>
+    </footer>
+  );
+}

--- a/src/components/SiteHeaderEn.tsx
+++ b/src/components/SiteHeaderEn.tsx
@@ -1,0 +1,33 @@
+import Link from 'next/link';
+
+// Chrome EN — espelho mínimo do SiteHeader pt (ADR-0006: árvores paralelas).
+// O nav cresce conforme as páginas EN entram (ordem do roadmap do ADR).
+const NAV_EN = [
+  { href: '/en/self-operating-app', label: 'What it is' },
+  { href: '/en/pricing', label: 'Pricing' },
+] as const;
+
+export default function SiteHeaderEn({ ptHref }: { ptHref: string }) {
+  return (
+    <header className="bg-white" style={{ borderBottom: '1px solid var(--line)' }}>
+      <div
+        className="wrap"
+        style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '14px 24px' }}
+      >
+        <Link href="/en" aria-label="Fluxomind — English home">
+          <img src="/logoSVG/logo-light.svg" alt="Fluxomind" style={{ height: 30 }} />
+        </Link>
+        <nav style={{ display: 'flex', gap: 18, alignItems: 'center', fontSize: 14.5 }}>
+          {NAV_EN.map((l) => (
+            <Link key={l.href} href={l.href}>
+              {l.label}
+            </Link>
+          ))}
+          <Link href={ptHref} lang="pt-BR">
+            Português →
+          </Link>
+        </nav>
+      </div>
+    </header>
+  );
+}

--- a/src/components/SiteHeaderEn.tsx
+++ b/src/components/SiteHeaderEn.tsx
@@ -1,7 +1,11 @@
+import Image from 'next/image';
 import Link from 'next/link';
+import { CTA_EN } from '@/lib/messages-en';
 
-// Chrome EN — espelho mínimo do SiteHeader pt (ADR-0006: árvores paralelas).
-// O nav cresce conforme as páginas EN entram (ordem do roadmap do ADR).
+// Chrome EN — mesmo padrão visual do SiteHeader pt (nav escura sticky do
+// globals.css). O nav cresce conforme as páginas EN entram (roadmap do
+// ADR-0006). Sem MobileNav por ora: ≤1040px os links colapsam via CSS e o
+// CTA permanece; menu hambúrguer EN entra quando o nav tiver mais itens.
 const NAV_EN = [
   { href: '/en/self-operating-app', label: 'What it is' },
   { href: '/en/pricing', label: 'Pricing' },
@@ -9,25 +13,34 @@ const NAV_EN = [
 
 export default function SiteHeaderEn({ ptHref }: { ptHref: string }) {
   return (
-    <header className="bg-white" style={{ borderBottom: '1px solid var(--line)' }}>
-      <div
-        className="wrap"
-        style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '14px 24px' }}
-      >
-        <Link href="/en" aria-label="Fluxomind — English home">
-          <img src="/logoSVG/logo-light.svg" alt="Fluxomind" style={{ height: 30 }} />
+    <nav>
+      <div className="wrap">
+        <Link href="/en" className="brand" aria-label="Fluxomind — English home">
+          <Image
+            src="/logoSVG/logo-dark.svg"
+            alt="Fluxomind"
+            width={292}
+            height={49}
+            className="brandlogo"
+            priority
+          />
         </Link>
-        <nav style={{ display: 'flex', gap: 18, alignItems: 'center', fontSize: 14.5 }}>
+        <div className="navlinks">
           {NAV_EN.map((l) => (
             <Link key={l.href} href={l.href}>
               {l.label}
             </Link>
           ))}
           <Link href={ptHref} lang="pt-BR">
-            Português →
+            Português
           </Link>
-        </nav>
+        </div>
+        <div className="navright">
+          <Link className="btn btn-primary nav-cta" href="/demo">
+            {CTA_EN.demo}
+          </Link>
+        </div>
       </div>
-    </header>
+    </nav>
   );
 }

--- a/src/lib/messages-en.ts
+++ b/src/lib/messages-en.ts
@@ -1,0 +1,52 @@
+// English canonical copy — mirror of messages.ts under docs/message-house-en.md
+// (PROPOSTA — aguardando martelo). One term only for the category:
+// "self-operating app". Do not invent copy outside the EN message house.
+
+export const SIGNATURE_EN = 'Delegate the task. Get the conclusion — with the proof.';
+
+export const PROMISE_EN =
+  'An app that solves your problem and runs itself — integrated with what you already use, governed, live in weeks (not a months-long project).';
+
+export const PURPOSE_LINE_EN =
+  'For 30 years, companies adapted to their software. We exist to invert that: software that molds itself to your business — and works for it.';
+
+export const NEGATION_EN = {
+  nots: [
+    'Not a chatbot that just replies.',
+    'Not a builder that hands you code to maintain.',
+    'Not a months-long IT project.',
+  ],
+  is: "It's a self-operating app: it builds itself from your problem, runs the day-to-day — and hands the sensitive calls to a human.",
+} as const;
+
+export const DEFINITION_EN =
+  "A self-operating app is an app that builds itself from your business problem, runs the day-to-day of the process — and escalates to a human when the case demands it. It's the third category of software, between rigid systems that force the company to adapt and human consulting that doesn't scale: software that molds itself to the business and works for it.";
+
+export const FACES_EN = [
+  { label: 'Domain', q: 'What does the business keep?', gloss: 'your data and concepts' },
+  { label: 'Experience', q: 'What do people see and do?', gloss: 'screens and interaction' },
+  { label: 'Intelligence', q: 'What thinks and helps decide?', gloss: 'decisions and next steps' },
+  { label: 'Process', q: 'What happens on its own?', gloss: 'the day-to-day that runs without you' },
+  { label: 'Connections', q: 'What does it talk to?', gloss: 'WhatsApp, e-mail, API, your systems' },
+  { label: 'Trust', q: 'Who can access what?', gloss: 'permissions, isolation and proof' },
+] as const;
+
+export const TRUST_RULES_EN = [
+  { title: 'Framing', desc: 'solves the right problem' },
+  { title: 'Coherence', desc: 'makes sense, end to end' },
+  { title: 'Fix + undo', desc: "mistakes don't hurt" },
+  { title: 'Human takes over', desc: 'a person decides the sensitive cases' },
+  { title: 'Your data, yours only', desc: 'truly isolated' },
+] as const;
+
+export const PHASE_EN = {
+  exists: 'Already real: the platform — 39 engines that materialize and operate real apps, multi-tenant, governed.',
+  next: 'Next chapter: dogfooding — Fluxomind running its own sales operation inside the product, the living proof that the agent operates and evolves.',
+  vision: 'The vision: a catalog of self-operating apps created by experts — someone who masters a problem packages the method; your company installs it and adopts it operated.',
+} as const;
+
+export const CTA_EN = {
+  demo: 'Create an app by talking',
+  demoNote: 'Live interactive demo (in Portuguese)',
+  contact: 'Talk to the team',
+} as const;


### PR DESCRIPTION
## O que muda

Fases 0-2 do plano i18n, no escopo **credibilidade internacional** (aquisição EN completa fica como projeto futuro):

- **`docs/message-house-en.md`** — a lei de copy EN (PROPOSTA), derivada 1:1 da pt. Contém a decisão que precisa do seu martelo: **o termo da categoria em inglês**. Recomendo **"self-operating app"** — autoexplicativo, ecoa "se opera sozinho", e verifiquei: nenhum player é dono do termo em busca. Alternativas avaliadas e descartadas na tabela (operating app colide com "operating system"; operant app soa skinneriano; autonomous app superpromete).
- **`/en`** — landing condensada com as redações canônicas EN; demo segue em português com moldura honesta *"live interactive demo (in Portuguese)"*.
- **`/en/self-operating-app`** — a página da categoria em inglês, mesmo formato GEO da pt (definition-first, FAQ, `FAQPage` + `DefinedTerm` JSON-LD).
- **hreflang** pt-BR↔en nos 4 pares; sitemap com 17 rotas; footer pt ganha "English"; páginas EN têm header/footer mínimos próprios com retorno ao pt.
- Sem dependência nova (dicionário próprio em `messages-en.ts`); se o EN escalar para aquisição, migramos para `[locale]` + next-intl.

## Validação
- `tsc`, build (25 rotas, `/en/*` estáticas) ✅; h1, DefinedTerm e hreflang verificados no HTML ✅

## ⚠️ Martelo do fundador
1. **O termo**: "self-operating app" (tabela de decisão no message-house-en.md) — é decisão de marca/categoria, upstream (vale registrar no BCM quando ratificar).
2. Toda a copy EN (traduções das redações canônicas).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YHBvrCZKmoPhGav9FesF6g