### PR TITLE
EN onda 1: security, what-it-does e accelerate

### DIFF
--- a/docs/leads-analytics.md
+++ b/docs/leads-analytics.md
@@ -85,7 +85,8 @@ Casos de uso: `casos-hub-<slug>` (card do hub), `casos-hub-demo-cta`,
 `app-operante-demo-cta`, `app-operante-beta-cta`. Bloco "O pedido, em
 português": `caso-<slug>-pedido-demo-cta`. Páginas EN: `en-home-demo-cta`,
 `en-home-contact-cta`, `en-soa-demo-cta`, `en-soa-contact-cta`,
-`en-pricing-demo-cta`, `en-pricing-contact-cta`.
+`en-pricing-demo-cta`, `en-pricing-contact-cta`, `en-wid-demo-cta`,
+`en-wid-contact-cta`, `en-security-contact-cta`, `en-accelerate-contact-cta`.
 
 **O funil que importa** (BCM: instrumentar tudo):
 `pageview(/)` → `demo_run` → `demo_built` → `demo_ops_run` → `demo_ops_done` →

--- a/src/app/acelere/page.tsx
+++ b/src/app/acelere/page.tsx
@@ -9,6 +9,10 @@ export const metadata: Metadata = {
   title: 'Acelere — do piloto à produção',
   description:
     'Para a empresa que já tentou IA e viu pilotos morrerem: 79% adotaram agentes (PwC, 2025), só 11% os têm implantados (KPMG, 2025). A Fluxomind entrega o processo operado — o agente roda o dia a dia, um humano decide nos casos sensíveis, integrado ao que você já tem.',
+  alternates: {
+    canonical: '/acelere',
+    languages: { 'pt-BR': '/acelere', en: '/en/accelerate' },
+  },
 };
 
 const ICON_PROPS = {

--- a/src/app/en/accelerate/page.tsx
+++ b/src/app/en/accelerate/page.tsx
@@ -1,0 +1,305 @@
+import Link from 'next/link';
+import type { Metadata } from 'next';
+import SiteHeaderEn from '@/components/SiteHeaderEn';
+import SiteFooterEn from '@/components/SiteFooterEn';
+import { SIGNATURE_EN, NEGATION_EN, PHASE_EN, CTA_EN } from '@/lib/messages-en';
+import { PLATFORM_CONTACT } from '@/lib/platform';
+
+export const metadata: Metadata = {
+  title: 'Accelerate — from pilot to production',
+  description:
+    'For the company that already tried AI and watched pilots die: 79% adopted agents (PwC, 2025), only 11% have them deployed (KPMG, 2025). Fluxomind delivers the process operated — the agent runs the day-to-day, a human decides the sensitive cases, integrated with what you already have.',
+  alternates: {
+    canonical: '/en/accelerate',
+    languages: { 'pt-BR': '/acelere', en: '/en/accelerate' },
+  },
+};
+
+// Espelho EN de /acelere (ADR-0006). Estatísticas com fonte (PwC/KPMG)
+// traduzem direto — as fontes são internacionais.
+const ICON_PROPS = {
+  viewBox: '0 0 24 24',
+  fill: 'none',
+  stroke: 'currentColor',
+  strokeWidth: 1.8,
+  strokeLinecap: 'round' as const,
+  strokeLinejoin: 'round' as const,
+};
+
+const WALLS = [
+  {
+    icon: (
+      <svg {...ICON_PROPS} width={26} height={26}>
+        <path d="M7 9h10v3a5 5 0 0 1-10 0V9z" />
+        <path d="M9.5 9V5M14.5 9V5M12 17v4" />
+      </svg>
+    ),
+    title: 'The prototype lives alone',
+    desc: 'Your operation lives in the ERP, the CRM, e-mail and WhatsApp. A pilot that doesn’t talk to them never enters anyone’s routine — no matter how good the demo was.',
+  },
+  {
+    icon: (
+      <svg {...ICON_PROPS} width={26} height={26}>
+        <path d="M12 3l7 3v5c0 4.5-3 8-7 10-4-2-7-5.5-7-10V6l7-3z" />
+        <path d="M12 8.5v4M12 15.5h.01" />
+      </svg>
+    ),
+    title: 'Security blocks what is not governed',
+    desc: 'Without permissions, limits and an audit trail, the pilot doesn’t make it past the committee. Rightly so: nobody hands a real process to something that doesn’t account for itself.',
+  },
+  {
+    icon: (
+      <svg {...ICON_PROPS} width={26} height={26}>
+        <rect x="4" y="5" width="16" height="15" rx="2" />
+        <path d="M8 3v4M16 3v4M4 10h16" />
+      </svg>
+    ),
+    title: 'Nobody owns Monday morning',
+    desc: 'The model answers well — but who runs the process every week, handles the exceptions and never drops the ball? Without an owner of the operation, the pilot becomes one more open tab.',
+  },
+];
+
+const OPERATED = [
+  {
+    icon: (
+      <svg {...ICON_PROPS}>
+        <path d="M20 12a8 8 0 1 1-2.3-5.7" />
+        <path d="M20 3v4h-4" />
+      </svg>
+    ),
+    tag: 'Process',
+    title: 'The agent runs the day-to-day',
+    desc: 'Collections that track the delay, follow-ups that never forget, approvals that keep moving. The process happens without depending on someone remembering it.',
+  },
+  {
+    icon: (
+      <svg {...ICON_PROPS}>
+        <circle cx="9" cy="8" r="3.2" />
+        <path d="M3.5 19c.6-3 2.7-4.6 5.5-4.6 1.2 0 2.3.3 3.2.9" />
+        <path d="M14.5 17.5l2 2 4-4" />
+      </svg>
+    ),
+    tag: 'Handoff',
+    title: 'A human decides the sensitive cases',
+    desc: 'When the case demands it — a discount beyond the limit, a delicate customer, a high amount — the app escalates to a person on your team. The AI proposes; whoever is in charge decides.',
+  },
+  {
+    icon: (
+      <svg {...ICON_PROPS}>
+        <path d="M12 3l7 3v5c0 4.5-3 8-7 10-4-2-7-5.5-7-10V6l7-3z" />
+        <path d="M9 12l2 2 4-4" />
+      </svg>
+    ),
+    tag: 'Governance',
+    title: 'Governed, with proof of every action',
+    desc: 'Permissions, usage limits and a tamper-evident audit trail at every step. Every conclusion arrives with the evidence of what was done.',
+  },
+  {
+    icon: (
+      <svg {...ICON_PROPS}>
+        <circle cx="12" cy="12" r="2.5" />
+        <circle cx="4.5" cy="6" r="1.8" />
+        <circle cx="19.5" cy="6" r="1.8" />
+        <circle cx="4.5" cy="18" r="1.8" />
+        <circle cx="19.5" cy="18" r="1.8" />
+        <path d="M10 10.2L6 7.4M14 10.2L18 7.4M10 13.8L6 16.6M14 13.8L18 16.6" />
+      </svg>
+    ),
+    tag: 'Integration',
+    title: 'Sits around what you already have',
+    desc: 'SAP, Salesforce and TOTVS stay exactly where they are — the app operates around them, integrating via API, e-mail and WhatsApp, with no replacement project.',
+  },
+];
+
+export default function AccelerateEn() {
+  return (
+    <div className="page-ent" lang="en">
+      <SiteHeaderEn ptHref="/acelere" />
+
+      <header className="hero">
+        <div className="wrap">
+          <div>
+            <span className="pill">For companies · AI adoption at scale</span>
+          </div>
+          <div className="kick" style={{ marginTop: 18 }}>{SIGNATURE_EN}</div>
+          <h1 style={{ maxWidth: '22ch' }}>
+            The AI pilot impressed in the demo — <span className="g">and died before production.</span>
+          </h1>
+          <p className="hsub">
+            If that story happened in your company, the model wasn&apos;t the problem — building
+            was never the bottleneck. What kills the pilot is what comes after: integrating,
+            governing and operating every day. <strong>That is exactly the part Fluxomind
+            delivers.</strong>
+          </p>
+          <div className="herocta">
+            <a className="btn btn-primary" href={PLATFORM_CONTACT} data-track="en-accelerate-contact-cta">
+              {CTA_EN.contact}
+            </a>
+            <a className="btn btn-ghost" href="#operated">
+              See what changes
+            </a>
+          </div>
+          <div className="stat">
+            <div className="s">
+              <b>79%</b>
+              <span>of companies have already adopted AI agents (PwC, May 2025)</span>
+            </div>
+            <div className="s">
+              <b>11%</b>
+              <span>actually have them deployed (KPMG, 2025)</span>
+            </div>
+            <div className="s">
+              <b>building ≠ operating</b>
+              <span>the gap where pilots die</span>
+            </div>
+          </div>
+        </div>
+      </header>
+
+      <section id="why-pilots-die">
+        <div className="wrap">
+          <div className="center">
+            <div className="kick">Why pilots die</div>
+            <h2>The pilot proves the AI works. It doesn&apos;t prove it operates.</h2>
+            <p className="lead" style={{ marginTop: 14 }}>
+              Between the demo and production, three walls appear — and none of them is the model.
+            </p>
+          </div>
+          <div className="prob">
+            {WALLS.map((w) => (
+              <div className="pcard" key={w.title}>
+                <div className="pi" aria-hidden="true" style={{ color: 'var(--blue)', lineHeight: 0 }}>
+                  {w.icon}
+                </div>
+                <h3>{w.title}</h3>
+                <p>{w.desc}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section style={{ paddingTop: 0 }}>
+        <div className="wrap">
+          <div className="fit">
+            <div className="kick" style={{ color: 'var(--sky)' }}>
+              The difference
+            </div>
+            <h2 style={{ color: '#fff', maxWidth: '24ch' }}>
+              Not one more pilot to test. The process delivered running.
+            </h2>
+            <ul
+              style={{ listStyle: 'none', marginTop: 26, display: 'flex', flexDirection: 'column', gap: 10 }}
+            >
+              {NEGATION_EN.nots.map((n) => (
+                <li
+                  key={n}
+                  style={{ display: 'flex', gap: 10, alignItems: 'flex-start', color: '#A9AEB8', fontSize: 16 }}
+                >
+                  <span aria-hidden="true" style={{ color: '#e07a5f', fontWeight: 700 }}>✕</span>
+                  {n}
+                </li>
+              ))}
+            </ul>
+            <p style={{ marginTop: 22, fontSize: 19, color: '#fff', fontWeight: 600, maxWidth: '58ch', lineHeight: 1.55 }}>
+              {NEGATION_EN.is}
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <section id="operated" style={{ paddingTop: 0 }}>
+        <div className="wrap">
+          <div className="center">
+            <div className="kick">Delivered operated</div>
+            <h2>What arrives at your company arrives running</h2>
+            <p className="lead" style={{ marginTop: 14 }}>
+              You don&apos;t receive a tool for the team to learn. You receive the process in
+              operation — and this is how it runs.
+            </p>
+          </div>
+          <div className="ways">
+            {OPERATED.map((o) => (
+              <div className="way" key={o.title}>
+                <div className="wi" aria-hidden="true">{o.icon}</div>
+                <h3>{o.title}</h3>
+                <div className="tagm">{o.tag}</div>
+                <p>{o.desc}</p>
+              </div>
+            ))}
+          </div>
+          <div className="fitlink" style={{ textAlign: 'center' }}>
+            <Link href="/en/security">
+              How governance and security work, in detail →
+            </Link>
+          </div>
+        </div>
+      </section>
+
+      <section id="model" style={{ paddingTop: 0 }}>
+        <div className="wrap">
+          <div className="center">
+            <div className="kick">Adoption model</div>
+            <h2>Start with one process. In weeks — not a months-long project.</h2>
+          </div>
+          <div className="timeline">
+            <div className="tl">
+              <div className="num">1</div>
+              <h4>One process, accompanied</h4>
+              <p>
+                Together we pick a process that hurts — collections, support, approvals. Our team
+                accompanies you from design to the first real conclusion.
+              </p>
+            </div>
+            <div className="tl">
+              <div className="num">2</div>
+              <h4>Proof in the day-to-day</h4>
+              <p>
+                The app operates and your team sees every conclusion with the proof — in the real
+                process, not on a slide. It is the evidence the pilot never had.
+              </p>
+            </div>
+            <div className="tl">
+              <div className="num">3</div>
+              <h4>Expansion, area by area</h4>
+              <p>
+                Value proven, other processes come in. Governance stays central; each area gets
+                its own self-operating app.
+              </p>
+            </div>
+          </div>
+          <div className="honest">
+            <b>Transparency.</b> {PHASE_EN.exists} We are in beta — adoption happens closely
+            accompanied by our team; formal SLAs and certifications are on the roadmap.{' '}
+            {PHASE_EN.vision}
+          </div>
+        </div>
+      </section>
+
+      <section style={{ paddingTop: 0 }}>
+        <div className="wrap">
+          <div className="cta-card" id="contact">
+            <div className="kick" style={{ color: 'var(--sky)' }}>
+              Let&apos;s talk
+            </div>
+            <h2>Bring the pilot that died. Leave with a process operating.</h2>
+            <p className="lead">
+              Tell us which process you want to delegate. We design your company&apos;s first
+              self-operating app with your team — and you follow every conclusion, with the proof.
+            </p>
+            <div className="ctab">
+              <a className="btn btn-primary" href={PLATFORM_CONTACT} data-track="en-accelerate-contact-cta">
+                {CTA_EN.contact}
+              </a>
+              <Link className="btn btn-ghost" href="/en/security">
+                See the security in depth
+              </Link>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <SiteFooterEn />
+    </div>
+  );
+}

--- a/src/app/en/security/page.tsx
+++ b/src/app/en/security/page.tsx
@@ -1,0 +1,380 @@
+import Link from 'next/link';
+import type { Metadata } from 'next';
+import SiteHeaderEn from '@/components/SiteHeaderEn';
+import SiteFooterEn from '@/components/SiteFooterEn';
+import { TRUST_RULES_EN, CTA_EN } from '@/lib/messages-en';
+import { PLATFORM_CONTACT } from '@/lib/platform';
+
+export const metadata: Metadata = {
+  title: 'Security & Governance',
+  description:
+    'Why you can delegate without fear: the 5 trust rules — framing, coherence, fix + undo, human in the loop and isolated data — what backs each one in the platform today, and honesty about what is not ready yet.',
+  alternates: {
+    canonical: '/en/security',
+    languages: { 'pt-BR': '/seguranca', en: '/en/security' },
+  },
+};
+
+// Espelho EN de /seguranca (ADR-0006). Os fatos técnicos (GUARANTEES,
+// compliance) são os mesmos do fact-check pt (PR #26) — tradução preserva
+// os claims exatos, sem overclaim.
+const ICON_PROPS = {
+  viewBox: '0 0 24 24',
+  fill: 'none',
+  stroke: 'currentColor',
+  strokeWidth: 1.8,
+  strokeLinecap: 'round' as const,
+  strokeLinejoin: 'round' as const,
+};
+
+const GUARANTEES = [
+  {
+    icon: (
+      <svg {...ICON_PROPS}>
+        <rect x="4" y="4" width="7" height="7" rx="1.4" />
+        <rect x="13" y="13" width="7" height="7" rx="1.4" />
+        <path d="M7.5 11v3.5a2 2 0 0 0 2 2H13" />
+      </svg>
+    ),
+    area: 'Isolation',
+    title: 'Your data stays yours only',
+    desc: 'Each company has a dedicated space. One customer never reaches another’s data — not by accident, not on purpose.',
+    how: 'Dedicated schema per customer + RLS as backstop. The tenantId derives from the request context, never from the payload.',
+    trail: 'securityEngine · dataEngine',
+  },
+  {
+    icon: (
+      <svg {...ICON_PROPS}>
+        <circle cx="8" cy="8" r="4" />
+        <path d="M11 11l8 8M16 16l2-2M14 18l2-2" />
+      </svg>
+    ),
+    area: 'BYOK',
+    title: 'The key is yours — and so is the lock',
+    desc: 'Those who require it can bring their own encryption key. Revoked it? The data becomes unreadable immediately — with or without us in the middle.',
+    how: 'BYOK with KMS (AWS/GCP/Azure) and crypto-shredding: revocation cuts access to the data, independently of the platform.',
+    trail: 'securityEngine · spec-byok',
+  },
+  {
+    icon: (
+      <svg {...ICON_PROPS}>
+        <path d="M2 12s3.5-6 10-6 10 6 10 6-3.5 6-10 6-10-6-10-6z" />
+        <circle cx="12" cy="12" r="2.6" />
+        <path d="M4 4l16 16" />
+      </svg>
+    ),
+    area: 'Privacy',
+    title: 'What is sensitive never reaches the model raw',
+    desc: 'Personal data is masked before any AI processes it — and there are guards against attempts to manipulate the model.',
+    how: 'PII masking (4 strategies) before the LLM + content safety against prompt-injection and jailbreak.',
+    trail: 'securityEngine · spec-content-safety',
+  },
+  {
+    icon: (
+      <svg {...ICON_PROPS}>
+        <path d="M12 3l7 3v5c0 4.5-3 8-7 10-4-2-7-5.5-7-10V6l7-3z" />
+        <path d="M9 12l2 2 4-4" />
+      </svg>
+    ),
+    area: 'Audit',
+    title: 'Every action recorded, tamper-evident',
+    desc: 'Who did what, when — in a trail that cannot be edited without leaving a mark. Verifiable by you, not on our word.',
+    how: 'Dual-token authentication + RBAC; SHA-256 append-only trail — tampering is cryptographically detectable and verifiable per tenant.',
+    trail: 'securityEngine · auditTrailEngine · spec-hash-chain',
+  },
+];
+
+const GOVERNANCE = [
+  {
+    title: 'Human in the loop (HITL)',
+    desc: 'Tiered approvals: nothing critical executes without the OK of whoever is in charge. The AI proposes; the decision that matters stays with you.',
+  },
+  {
+    title: 'Policies and roles',
+    desc: 'RBAC and policies decide who can do what — enforced by the platform at every step, not trusted to each app’s code.',
+  },
+  {
+    title: 'Quotas and usage limits',
+    desc: 'Usage metered and gated per tenant, with atomic reservation. No silent overruns, no consumption surprises.',
+  },
+  {
+    title: 'Consent and privacy',
+    desc: 'GDPR/LGPD consent lifecycle with a trail — legal basis recorded, not presumed.',
+  },
+];
+
+export default function SecurityEn() {
+  return (
+    <div className="page-feats" lang="en">
+      <SiteHeaderEn ptHref="/seguranca" />
+
+      <header className="hero">
+        <div className="wrap">
+          <div className="center">
+            <div className="kick" style={{ color: 'var(--sky)' }}>
+              Security &amp; Governance
+            </div>
+            <h1>
+              Trust to delegate — <span className="g">even what is sensitive.</span>
+            </h1>
+            <p className="hsub" style={{ margin: '18px auto 0', maxWidth: '62ch' }}>
+              Finance, health, legal: the processes most worth delegating are the scariest ones.
+              That is why security here is not a compliance annex — it is{' '}
+              <strong>five rules in the path of every action</strong> your app executes. This
+              page shows what backs each one, and is honest about what is not ready yet.
+            </p>
+            <div className="herocta" style={{ justifyContent: 'center', marginTop: 26 }}>
+              <a className="btn btn-primary" href="#rules">
+                See the five rules
+              </a>
+              <a className="btn btn-ghost" href={PLATFORM_CONTACT} data-track="en-security-contact-cta">
+                {CTA_EN.contact}
+              </a>
+            </div>
+          </div>
+        </div>
+      </header>
+
+      <section className="sec" id="rules">
+        <div className="wrap">
+          <div className="center">
+            <div className="kick" style={{ color: 'var(--sky)' }}>
+              The trust rules
+            </div>
+            <h2 style={{ color: '#fff' }}>What makes the operation trustworthy — in five rules</h2>
+            <p className="lead" style={{ color: '#A9AEB8', marginTop: 14 }}>
+              Not audit jargon. These are the conditions for a non-technical person to delegate a
+              real operation — and every product decision in the platform answers to them.
+            </p>
+          </div>
+          <div style={{ display: 'flex', flexWrap: 'wrap', gap: 14, marginTop: 34 }}>
+            {TRUST_RULES_EN.map((r, i) => (
+              <div className="secc" key={r.title} style={{ flex: '1 1 176px' }}>
+                <div className="mono" style={{ color: 'var(--sky)', fontWeight: 700 }}>
+                  0{i + 1}
+                </div>
+                <h4>{r.title}</h4>
+                <p>{r.desc}</p>
+              </div>
+            ))}
+          </div>
+          <div className="center" style={{ marginTop: 30 }}>
+            <span className="scar">
+              This is what opens the most sensitive domains — finance, health, legal.
+            </span>
+            <p style={{ color: '#7e8590', fontSize: 14, marginTop: 18, maxWidth: '58ch', marginLeft: 'auto', marginRight: 'auto' }}>
+              Below, what backs each rule: the way apps are built (rules 1 and 2), governance in
+              the path of every action (3 and 4), and the isolation-and-proof engineering (5).
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <section id="building">
+        <div className="wrap">
+          <div className="secthead">
+            <div className="kick">Rules 1 and 2 · Framing and coherence</div>
+            <h2>You watch the app being born — and check before you trust</h2>
+            <p className="lead" style={{ marginTop: 14, maxWidth: '62ch' }}>
+              Your app doesn&apos;t arrive in a black box. It builds itself from your problem, in
+              front of you — and every conclusion arrives with the proof. Wrong framing shows up
+              on the first screen, not months into a project.
+            </p>
+          </div>
+          <div style={{ marginTop: 24 }}>
+            <div className="feat">
+              <span className="ck">✓</span>
+              <div>
+                <h4>Solves the right problem</h4>
+                <p>
+                  Construction starts from the description of your problem, and you follow every
+                  step on screen. What doesn&apos;t make sense for your business, you adjust by
+                  talking — no tickets, no waiting for a sprint.
+                </p>
+              </div>
+            </div>
+            <div className="feat">
+              <span className="ck">✓</span>
+              <div>
+                <h4>Makes sense, end to end</h4>
+                <p>
+                  Not a slice that pushes the rest for later: the solution is born whole and
+                  coherent, and the conclusion of each stage comes with the evidence for you to
+                  check.
+                </p>
+              </div>
+            </div>
+          </div>
+          <p style={{ marginTop: 18 }}>
+            <Link href="/demo" style={{ color: 'var(--blue)', fontWeight: 600, fontSize: 15 }}>
+              {CTA_EN.demo} → <span style={{ color: 'var(--slate)', fontWeight: 400 }}>({CTA_EN.demoNote})</span>
+            </Link>
+          </p>
+        </div>
+      </section>
+
+      <section id="governance" style={{ background: 'var(--panel)' }}>
+        <div className="wrap">
+          <div className="secthead">
+            <div className="kick">Rules 3 and 4 · Mistakes don&apos;t hurt, a human takes over</div>
+            <h2>The AI truly executes — inside your rules</h2>
+            <p className="lead" style={{ marginTop: 14, maxWidth: '62ch' }}>
+              The difference between an AI that helps and one that scares is who decides. Here,
+              governance is not a separate dashboard: it sits in the path of every action your
+              app executes — so that mistakes don&apos;t hurt and, in the sensitive cases, a
+              person decides.
+            </p>
+          </div>
+          <div style={{ marginTop: 24 }}>
+            {GOVERNANCE.map((it) => (
+              <div className="feat" key={it.title}>
+                <span className="ck">✓</span>
+                <div>
+                  <h4>{it.title}</h4>
+                  <p>{it.desc}</p>
+                </div>
+              </div>
+            ))}
+          </div>
+          <div style={{ marginTop: 18 }}>
+            <span className="badge b-parc">
+              <span className="d" /> Partial — advanced governance maturing
+            </span>
+          </div>
+        </div>
+      </section>
+
+      <section className="sec" id="guarantees">
+        <div className="wrap">
+          <div className="center">
+            <div className="kick" style={{ color: 'var(--sky)' }}>
+              Rule 5 · Your data, yours only
+            </div>
+            <h2 style={{ color: '#fff' }}>What protects your data — and how to prove it</h2>
+            <p className="lead" style={{ color: '#A9AEB8', marginTop: 14 }}>
+              Four foundation protections, active from day one — each with the engineering trail
+              that backs it.
+            </p>
+          </div>
+          <div className="secg">
+            {GUARANTEES.map((g) => (
+              <div className="secc" key={g.area}>
+                <div className="si">{g.icon}</div>
+                <div
+                  style={{
+                    color: 'var(--sky)',
+                    fontWeight: 700,
+                    fontSize: 12,
+                    letterSpacing: '.04em',
+                    textTransform: 'uppercase',
+                    marginTop: 12,
+                  }}
+                >
+                  {g.area}
+                </div>
+                <h4>{g.title}</h4>
+                <p>{g.desc}</p>
+                <p style={{ color: '#7e8590', marginTop: 9 }}>{g.how}</p>
+                <div
+                  style={{
+                    fontSize: 11,
+                    color: '#6b7280',
+                    marginTop: 9,
+                    fontFamily: 'ui-monospace, monospace',
+                  }}
+                >
+                  trail: {g.trail}
+                </div>
+              </div>
+            ))}
+          </div>
+          <div className="center" style={{ marginTop: 30 }}>
+            <span className="badge b-impl">
+              <span className="d" /> Implemented — verifiable in the architecture today
+            </span>
+          </div>
+        </div>
+      </section>
+
+      <section id="compliance">
+        <div className="wrap">
+          <div className="secthead">
+            <div className="kick">Compliance, honestly</div>
+            <h2>What is ready — and what is not yet</h2>
+            <p className="lead" style={{ marginTop: 14, maxWidth: '64ch' }}>
+              The platform has automated scanners for SOC2 controls (CC6/CC7/CC8) and GDPR
+              (Art. 17/20/30/32) — verification by code, not a manual checklist; today they run
+              on demand, and scheduled continuous execution is on the roadmap.{' '}
+              <strong>
+                We do not yet have a formal third-party SOC2 certification nor a completed
+                external pen-test
+              </strong>{' '}
+              — they are the next step, not a promise fulfilled. What we claim above is what can
+              be verified in the architecture today.
+            </p>
+          </div>
+          <table style={{ marginTop: 24 }}>
+            <thead>
+              <tr>
+                <th>Front</th>
+                <th>What we already deliver</th>
+                <th>Status</th>
+                <th>Next step</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td><b>Data protection</b></td>
+                <td>Multi-tenant isolation, BYOK, PII masking, hash-chain audit</td>
+                <td>
+                  <span className="badge b-impl"><span className="d" /> Implemented</span>
+                </td>
+                <td className="next">External pen-test</td>
+              </tr>
+              <tr>
+                <td><b>Governance</b></td>
+                <td>HITL, policies/RBAC, quotas/entitlements, consent</td>
+                <td>
+                  <span className="badge b-parc"><span className="d" /> Partial</span>
+                </td>
+                <td className="next">Broad fail-closed + more autonomy patterns</td>
+              </tr>
+              <tr>
+                <td><b>Compliance</b></td>
+                <td>Automated SOC2/GDPR scanners (on demand)</td>
+                <td>
+                  <span className="badge b-parc"><span className="d" /> Partial</span>
+                </td>
+                <td className="next">Continuous execution + SOC2 Type II certification (external audit)</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <section className="offer" id="evaluate">
+        <div className="wrap">
+          <div className="kick" style={{ color: 'var(--sky)' }}>
+            Deep evaluation
+          </div>
+          <h2>Going to pop the hood on security?</h2>
+          <p className="lead">
+            For those who need to evaluate in depth, we provide an isolated evaluation
+            environment and an architecture session with engineering — where every guarantee
+            above is demonstrated, not asserted.
+          </p>
+          <div className="offerbtns">
+            <a className="btn btn-primary btn-lg" href={PLATFORM_CONTACT} data-track="en-security-contact-cta">
+              {CTA_EN.contact}
+            </a>
+            <Link className="btn btn-ghost btn-lg" href="/en/what-it-does">
+              What your app answers →
+            </Link>
+          </div>
+        </div>
+      </section>
+
+      <SiteFooterEn />
+    </div>
+  );
+}

--- a/src/app/en/what-it-does/page.tsx
+++ b/src/app/en/what-it-does/page.tsx
@@ -1,0 +1,225 @@
+import Link from 'next/link';
+import type { Metadata } from 'next';
+import type { ReactNode } from 'react';
+import SiteHeaderEn from '@/components/SiteHeaderEn';
+import SiteFooterEn from '@/components/SiteFooterEn';
+import { FACES_EN, CTA_EN } from '@/lib/messages-en';
+import { PLATFORM_CONTACT } from '@/lib/platform';
+
+export const metadata: Metadata = {
+  title: 'What it does',
+  description:
+    'Every Fluxomind app answers six questions about your business — data, screens, decisions, the day-to-day, integrations and permissions — and starts operating the moment it exists. In weeks, not months.',
+  alternates: {
+    canonical: '/en/what-it-does',
+    languages: { 'pt-BR': '/o-que-tem', en: '/en/what-it-does' },
+  },
+};
+
+// Espelho EN de /o-que-tem (ADR-0006). O HexAgono360 fica de fora do v1 EN
+// (copy pt embutida no client component — parametrizar é melhoria futura).
+const ICON_PROPS = {
+  viewBox: '0 0 24 24',
+  fill: 'none',
+  stroke: 'currentColor',
+  strokeWidth: 1.8,
+  strokeLinecap: 'round' as const,
+  strokeLinejoin: 'round' as const,
+};
+
+const FACE_DETAILS: Record<string, { icon: ReactNode; desc: string }> = {
+  Domain: {
+    icon: (
+      <svg {...ICON_PROPS}>
+        <ellipse cx="12" cy="6" rx="7" ry="2.6" />
+        <path d="M5 6v6c0 1.4 3.1 2.6 7 2.6s7-1.2 7-2.6V6" />
+        <path d="M5 12v6c0 1.4 3.1 2.6 7 2.6s7-1.2 7-2.6v-6" />
+      </svg>
+    ),
+    desc: 'Customers, contracts, orders, tickets — the objects of your business, with fields and relations. You describe them in plain language; Fluxomind creates the data model, without you designing a single table.',
+  },
+  Experience: {
+    icon: (
+      <svg {...ICON_PROPS}>
+        <rect x="3" y="4" width="18" height="13" rx="1.5" />
+        <path d="M3 9h18M8.5 21h7M12 17v4" />
+      </svg>
+    ),
+    desc: 'Lists, forms, records and dashboards — generated for every object and adjusted by talking. The same operation becomes a screen on desktop, a conversation on WhatsApp, and voice.',
+  },
+  Intelligence: {
+    icon: (
+      <svg {...ICON_PROPS}>
+        <path d="M12 3l1.7 4.3L18 9l-4.3 1.7L12 15l-1.7-4.3L6 9l4.3-1.7L12 3z" />
+        <circle cx="18" cy="17.5" r="2" />
+      </svg>
+    ),
+    desc: 'Agents that truly execute — collect, reply, organize — backed by a brain that understands your business and searches your knowledge. Not a chatbot that just replies: it is work concluded.',
+  },
+  Process: {
+    icon: (
+      <svg {...ICON_PROPS}>
+        <rect x="3" y="4" width="6" height="5" rx="1" />
+        <rect x="15" y="15" width="6" height="5" rx="1" />
+        <path d="M6 9v4a3 3 0 0 0 3 3h6" />
+      </svg>
+    ),
+    desc: 'The heart of the self-operating app: automations and rules that run on events, data or triggers. The day-to-day happens without you — with approvals at the points that matter.',
+  },
+  Connections: {
+    icon: (
+      <svg {...ICON_PROPS}>
+        <path d="M8.7 15.3l-2 2a3.5 3.5 0 0 1-5-5l2-2M15.3 8.7l2-2a3.5 3.5 0 0 1 5 5l-2 2M9 15l6-6" />
+      </svg>
+    ),
+    desc: 'Connectors, API and MCP: your app pulls data from what you already use and even becomes a tool inside other systems. It integrates — it does not force a replacement.',
+  },
+  Trust: {
+    icon: (
+      <svg {...ICON_PROPS}>
+        <path d="M12 3l7 3v5c0 4.5-3 8-7 10-4-2-7-5.5-7-10V6l7-3z" />
+        <path d="M9 12l2 2 4-4" />
+      </svg>
+    ),
+    desc: 'Roles and permissions, data isolation, masking of what is sensitive and an audit trail — built in, in every app. And in the sensitive cases, a person decides: the app hands off to a human.',
+  },
+};
+
+const CARDS = FACES_EN.map((f) => ({ ...f, ...FACE_DETAILS[f.label] }));
+
+export default function WhatItDoesEn() {
+  return (
+    <div className="page-feats" lang="en">
+      <SiteHeaderEn ptHref="/o-que-tem" />
+
+      <header className="hero">
+        <div className="wrap">
+          <div className="center">
+            <div className="kick" style={{ color: 'var(--sky)' }}>
+              What it does
+            </div>
+            <h1>
+              One app, <span className="g">six questions about your business.</span>
+            </h1>
+            <p className="hsub" style={{ margin: '18px auto 0', maxWidth: '58ch' }}>
+              Every Fluxomind app is born answering six questions about your operation. You
+              don&apos;t assemble it module by module: you describe the problem and it sculpts the
+              whole app — which doesn&apos;t sit still: <strong>it starts running the day-to-day</strong>.
+            </p>
+            <div className="herocta" style={{ justifyContent: 'center', marginTop: 26 }}>
+              <Link className="btn btn-primary" href="/demo" data-track="en-wid-demo-cta">
+                {CTA_EN.demo}
+              </Link>
+              <a className="btn btn-ghost" href="#questions">
+                See the six questions
+              </a>
+            </div>
+            <p style={{ marginTop: 10, fontSize: 13.5, color: 'var(--slate)' }}>{CTA_EN.demoNote}</p>
+          </div>
+        </div>
+      </header>
+
+      <section id="questions">
+        <div className="wrap">
+          <div className="center">
+            <div className="kick">The six questions</div>
+            <h2>What your app answers</h2>
+            <p className="lead" style={{ margin: '14px auto 0', maxWidth: '58ch' }}>
+              Six answers, one single app — data, screens, decisions, the day-to-day,
+              integrations and permissions are born together, from the same conversation.
+            </p>
+          </div>
+
+          <div className="feats" style={{ marginTop: 40 }}>
+            {CARDS.map((f) => (
+              <div className="featx" key={f.label}>
+                <div className="fx">{f.icon}</div>
+                <div className="area">{f.label}</div>
+                <h3>{f.q}</h3>
+                <p>{f.desc}</p>
+                <span className="tag">{f.gloss}</span>
+              </div>
+            ))}
+          </div>
+
+          <div className="center" style={{ marginTop: 46 }}>
+            <p className="lead" style={{ maxWidth: '62ch', margin: '0 auto' }}>
+              Two of those questions hold the secret: <strong>Process</strong> makes the
+              day-to-day run without you, and <strong>Trust</strong> guarantees that, in the
+              sensitive case, a person decides. Your app doesn&apos;t just exist —{' '}
+              <strong>it operates</strong>. That is the difference between an app you use and an
+              app that works for you.
+            </p>
+            <div style={{ marginTop: 16 }}>
+              <Link href="/en/security" style={{ color: 'var(--blue)', fontWeight: 600 }}>
+                How trust is guaranteed →
+              </Link>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section>
+        <div className="wrap">
+          <div className="center">
+            <div className="kick">Why this is different</div>
+            <h2>Building got easy. Operating is what&apos;s missing.</h2>
+            <p className="lead" style={{ margin: '14px auto 0', maxWidth: '60ch' }}>
+              Any AI today hands you a prototype — and from there, the code is yours to
+              maintain. Fluxomind assembles the six answers{' '}
+              <strong>on top of a platform that is already standing</strong>, with data, screens,
+              governance and connections ready. The result is a self-operating app —{' '}
+              <strong>in weeks, not months</strong>.
+            </p>
+          </div>
+
+          <div className="appvs">
+            <div className="col bad">
+              <h4>Project generated by a code builder</h4>
+              <ul>
+                <li>Born from zero: code that becomes your responsibility forever.</li>
+                <li>Multi-tenant, roles and permissions? You implement them — or go without.</li>
+                <li>Every new request is more glued-on code; drift is a matter of time.</li>
+                <li>One surface only: what became web doesn&apos;t become WhatsApp or voice on its own.</li>
+                <li>Built, not operating: running the day-to-day is still your problem.</li>
+              </ul>
+            </div>
+            <div className="col good">
+              <h4>Fluxomind self-operating app</h4>
+              <ul>
+                <li>Assembled on a platform that is already standing: zero code for you to maintain.</li>
+                <li>Multi-tenancy, roles and permissions inherited out of the box, in every app.</li>
+                <li>Changes by talking — one source of truth, no accumulated drift.</li>
+                <li>The same operation becomes screen, WhatsApp, voice and a tool via MCP.</li>
+                <li>Runs the day-to-day and hands off to a human in the sensitive cases.</li>
+              </ul>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="offer">
+        <div className="wrap">
+          <div className="kick" style={{ color: 'var(--sky)' }}>
+            The next step
+          </div>
+          <h2>Want this answering for your business?</h2>
+          <p className="lead" style={{ maxWidth: '56ch', margin: '14px auto 0' }}>
+            See a self-operating app being born in the interactive demo — or talk directly to
+            the team.
+          </p>
+          <div className="offerbtns">
+            <Link className="btn btn-primary btn-lg" href="/demo" data-track="en-wid-demo-cta">
+              {CTA_EN.demo}
+            </Link>
+            <a className="btn btn-ghost btn-lg" href={PLATFORM_CONTACT} data-track="en-wid-contact-cta">
+              {CTA_EN.contact}
+            </a>
+          </div>
+        </div>
+      </section>
+
+      <SiteFooterEn />
+    </div>
+  );
+}

--- a/src/app/o-que-tem/page.tsx
+++ b/src/app/o-que-tem/page.tsx
@@ -11,6 +11,10 @@ export const metadata: Metadata = {
   title: 'O que faz',
   description:
     'Todo app da Fluxomind responde seis perguntas do seu negócio — dados, telas, decisões, o dia a dia, integrações e permissões — e passa a operar assim que existe. Em semanas, não meses.',
+  alternates: {
+    canonical: '/o-que-tem',
+    languages: { 'pt-BR': '/o-que-tem', en: '/en/what-it-does' },
+  },
 };
 
 // As 6 perguntas do seu app: redação canônica em src/lib/messages.ts (FACES).

--- a/src/app/seguranca/page.tsx
+++ b/src/app/seguranca/page.tsx
@@ -9,6 +9,10 @@ export const metadata: Metadata = {
   title: 'Segurança & Governança',
   description:
     'Por que delegar sem medo: as 5 regras da confiança — enquadramento, coerência, correção, humano no circuito e dados isolados — e o que sustenta cada uma na plataforma hoje, com honestidade sobre o que falta.',
+  alternates: {
+    canonical: '/seguranca',
+    languages: { 'pt-BR': '/seguranca', en: '/en/security' },
+  },
 };
 
 const ICON_PROPS = {

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -22,6 +22,9 @@ export default function sitemap(): MetadataRoute.Sitemap {
     { url: `${BASE_URL}/en`, changeFrequency: 'monthly', priority: 0.6 },
     { url: `${BASE_URL}/en/self-operating-app`, changeFrequency: 'monthly', priority: 0.6 },
     { url: `${BASE_URL}/en/pricing`, changeFrequency: 'monthly', priority: 0.5 },
+    { url: `${BASE_URL}/en/what-it-does`, changeFrequency: 'monthly', priority: 0.5 },
+    { url: `${BASE_URL}/en/security`, changeFrequency: 'monthly', priority: 0.5 },
+    { url: `${BASE_URL}/en/accelerate`, changeFrequency: 'monthly', priority: 0.5 },
     { url: `${BASE_URL}/terms`, changeFrequency: 'yearly', priority: 0.3 },
     { url: `${BASE_URL}/privacidade`, changeFrequency: 'yearly', priority: 0.3 },
   ];

--- a/src/components/SiteFooterEn.tsx
+++ b/src/components/SiteFooterEn.tsx
@@ -15,6 +15,9 @@ export default function SiteFooterEn() {
         <div style={{ display: 'flex', flexWrap: 'wrap', gap: 16, fontSize: 14 }}>
           <Link href="/en">English home</Link>
           <Link href="/en/self-operating-app">Self-operating app</Link>
+          <Link href="/en/what-it-does">What it does</Link>
+          <Link href="/en/security">Security</Link>
+          <Link href="/en/accelerate">Accelerate</Link>
           <Link href="/en/pricing">Pricing</Link>
           <Link href="/terms" lang="pt-BR">Termos de Uso</Link>
           <Link href="/privacidade" lang="pt-BR">Privacidade</Link>

--- a/src/components/SiteHeaderEn.tsx
+++ b/src/components/SiteHeaderEn.tsx
@@ -8,6 +8,9 @@ import { CTA_EN } from '@/lib/messages-en';
 // CTA permanece; menu hambúrguer EN entra quando o nav tiver mais itens.
 const NAV_EN = [
   { href: '/en/self-operating-app', label: 'What it is' },
+  { href: '/en/what-it-does', label: 'What it does' },
+  { href: '/en/security', label: 'Security' },
+  { href: '/en/accelerate', label: 'Accelerate' },
   { href: '/en/pricing', label: 'Pricing' },
 ] as const;
 


### PR DESCRIPTION
## O que muda

Onda 1 do roadmap i18n (ADR-0006) — 3 institucionais EN, espelhos fiéis das pt sob a lei `message-house-en.md`:

- **`/en/security`** ← /seguranca — claims técnicos idênticos ao fact-check pt (PR #26): RLS, BYOK + crypto-shredding, PII masking 4 estratégias, trilha SHA-256; tabela de compliance com a mesma honestidade ("não temos SOC2 formal nem pen-test externo — próximo passo").
- **`/en/what-it-does`** ← /o-que-tem — 6 perguntas + comparativo "code builder vs self-operating app". Nota: HexAgono360 omitido no v1 EN (client component com copy pt embutida; parametrizar é melhoria futura).
- **`/en/accelerate`** ← /acelere — estatísticas PwC/KPMG mantidas (fontes internacionais).

Nav/footer EN completos; hreflang par a par nos 3 pares pt; sitemap 21 rotas.

## Pendências conhecidas da árvore EN
- Menu hambúrguer EN (≤1040px os links colapsam e só fica o CTA) — entra no PR da /en/platform.
- Mailto com assunto pt no "Talk to the team".

## Validação
- `tsc`, build (26 rotas), lint ✅; as 3 páginas e o hreflang verificados no HTML ✅

## Martelo do fundador
Copy EN das 3 páginas (traduções fiéis, sem claim novo — mas é copy pública).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YHBvrCZKmoPhGav9FesF6g