### PR TITLE
EN final: why, use-cases, terms e privacy — site 100% EN/PT (exceto demo)

### DIFF
--- a/docs/leads-analytics.md
+++ b/docs/leads-analytics.md
@@ -87,7 +87,9 @@ português": `caso-<slug>-pedido-demo-cta`. Páginas EN: `en-home-demo-cta`,
 `en-home-contact-cta`, `en-soa-demo-cta`, `en-soa-contact-cta`,
 `en-pricing-demo-cta`, `en-pricing-contact-cta`, `en-wid-demo-cta`,
 `en-wid-contact-cta`, `en-security-contact-cta`, `en-accelerate-contact-cta`,
-`en-platform-contact-cta`.
+`en-platform-contact-cta`, `en-why-{demo,contact}-cta`,
+`en-cases-hub-<slug|demo-cta|contact-cta>`,
+`en-case-<slug>-{demo,request-demo,contact}-cta`.
 
 **O funil que importa** (BCM: instrumentar tudo):
 `pageview(/)` → `demo_run` → `demo_built` → `demo_ops_run` → `demo_ops_done` →

--- a/src/app/casos-de-uso/page.tsx
+++ b/src/app/casos-de-uso/page.tsx
@@ -9,6 +9,10 @@ export const metadata: Metadata = {
   title: 'Casos de uso — o que um app operante resolve no seu negócio',
   description:
     'Casos de uso da Fluxomind por processo de negócio: gestão de leads, cobrança e contas a receber, atendimento no WhatsApp. Cada caso mostra o que roda sozinho, onde um humano decide — e você pode viver o caso na demonstração interativa.',
+  alternates: {
+    canonical: '/casos-de-uso',
+    languages: { 'pt-BR': '/casos-de-uso', en: '/en/use-cases' },
+  },
 };
 
 // Hub dos casos de uso. Formato GEO: abertura definicional, cards por dor,

--- a/src/app/en/privacy/page.tsx
+++ b/src/app/en/privacy/page.tsx
@@ -1,0 +1,255 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+
+export const metadata: Metadata = {
+  title: 'Privacy Policy',
+  description:
+    'Fluxomind Privacy Policy — how we collect, use and protect your personal data under the Brazilian LGPD (courtesy translation — the Portuguese version prevails)',
+  alternates: {
+    canonical: '/en/privacy',
+    languages: { 'pt-BR': '/privacidade', en: '/en/privacy' },
+  },
+};
+
+// Tradução de cortesia de /privacidade (ADR-0006, onda legal). A base legal
+// segue sendo a LGPD (controladora brasileira); a versão pt prevalece.
+export default function PrivacyEn() {
+  const currentYear = new Date().getFullYear();
+  const lastUpdated = 'July 4, 2026';
+
+  return (
+    <div className="min-h-screen bg-white" lang="en">
+      <header className="bg-white shadow-sm border-b border-gray-100">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="flex justify-between items-center py-4">
+            <Link href="/en" className="flex items-center">
+              <img src="/logoSVG/logo-light.svg" alt="Fluxomind" className="h-8 w-auto" />
+            </Link>
+            <Link href="/privacidade" className="text-gray-600 hover:text-gray-900 transition-colors" lang="pt-BR">
+              Versão em português →
+            </Link>
+          </div>
+        </div>
+      </header>
+
+      <main className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+        <article className="prose prose-gray max-w-none">
+          <h1 className="text-3xl md:text-4xl font-bold text-gray-900 mb-4">Privacy Policy</h1>
+          <p className="text-gray-500 mb-4">Last updated: {lastUpdated}</p>
+          <div className="bg-blue-50 border border-blue-200 rounded-lg p-4 mb-8">
+            <p className="text-gray-700 text-sm">
+              This is a courtesy translation. In case of any conflict, the{' '}
+              <Link href="/privacidade" className="text-blue-600 hover:underline">
+                Portuguese version (Política de Privacidade)
+              </Link>{' '}
+              prevails. FLUXOMIND LTDA is a Brazilian company; the applicable law is the
+              Brazilian General Data Protection Law (LGPD — Law No. 13,709/2018).
+            </p>
+          </div>
+
+          <section className="mb-8">
+            <h2 className="text-2xl font-semibold text-gray-900 mb-4">1. Who we are</h2>
+            <p className="text-gray-600 mb-4">
+              This Privacy Policy describes how FLUXOMIND LTDA, enrolled with the CNPJ under No.
+              60.162.547/0001-15, headquartered in São Paulo/SP, Brazil (&quot;Fluxomind&quot;,
+              &quot;we&quot;), processes personal data collected through the website
+              www.fluxomind.com (&quot;Site&quot;), as controller, in compliance with the
+              Brazilian General Data Protection Law (LGPD) and the Brazilian Internet Civil
+              Framework (Law No. 12,965/2014).
+            </p>
+          </section>
+
+          <section className="mb-8">
+            <h2 className="text-2xl font-semibold text-gray-900 mb-4">2. What data we collect</h2>
+            <p className="text-gray-600 mb-4">
+              We collect only the minimum necessary to operate the Site and respond to your
+              interest:
+            </p>
+            <ul className="list-disc pl-6 text-gray-600 space-y-2 mb-4">
+              <li>
+                <strong>Data you send us:</strong> when filling in the beta interest form, we
+                collect name, e-mail, company and the description of the process you want to
+                automate.
+              </li>
+              <li>
+                <strong>Browsing data (anonymous):</strong> we record usage events on the Site
+                (pages visited, clicks and progress in the interactive demo) in a first-party
+                way, without cookies and without personal identification. We use only a random,
+                anonymous session identifier stored in your browser&apos;s sessionStorage, which
+                is automatically deleted when you close the tab.
+              </li>
+              <li>
+                <strong>Transient technical data:</strong> the IP address is used momentarily to
+                limit abuse (rate limiting) and may appear in the hosting infrastructure&apos;s
+                technical logs, which are retained for a short period.
+              </li>
+            </ul>
+          </section>
+
+          <section className="mb-8">
+            <h2 className="text-2xl font-semibold text-gray-900 mb-4">3. Why we use it and on which legal basis</h2>
+            <ul className="list-disc pl-6 text-gray-600 space-y-2 mb-4">
+              <li>
+                <strong>Responding to your interest in the beta:</strong> we use the form data to
+                contact you about the beta program and evaluate your use case. Legal basis:
+                consent (LGPD art. 7, I) and preliminary procedures related to a contract (LGPD
+                art. 7, V).
+              </li>
+              <li>
+                <strong>Understanding and improving the Site:</strong> we use anonymous browsing
+                events to measure the funnel and improve content. Legal basis: legitimate
+                interest (LGPD art. 7, IX) — with no identifiable personal data.
+              </li>
+              <li>
+                <strong>Security and abuse prevention:</strong> we use technical data to protect
+                the Site against fraud and misuse. Legal basis: legitimate interest (LGPD art. 7,
+                IX).
+              </li>
+            </ul>
+            <p className="text-gray-600">
+              We do not sell your personal data nor use it for third-party advertising.
+            </p>
+          </section>
+
+          <section className="mb-8">
+            <h2 className="text-2xl font-semibold text-gray-900 mb-4">4. Cookies</h2>
+            <p className="text-gray-600 mb-4">
+              The Site <strong>does not use cookies</strong> — neither first-party nor
+              third-party, nor for advertising or tracking. Usage measurement is done with an
+              anonymous session identifier in the browser&apos;s sessionStorage, which cannot
+              identify you and disappears when the tab is closed. That is why the Site shows no
+              cookie consent banner. If this practice changes, this Policy will be updated and
+              consent will be requested where required.
+            </p>
+          </section>
+
+          <section className="mb-8">
+            <h2 className="text-2xl font-semibold text-gray-900 mb-4">5. Who we share it with</h2>
+            <p className="text-gray-600 mb-4">
+              We share data only with processors essential to the Site&apos;s operation:
+            </p>
+            <ul className="list-disc pl-6 text-gray-600 space-y-2 mb-4">
+              <li><strong>Vercel</strong> — Site hosting and execution of the capture routes (United States);</li>
+              <li><strong>Google</strong> — internal storage of leads and events in corporate spreadsheets with restricted access (Google Workspace);</li>
+              <li><strong>Cloudflare</strong> — domain and DNS management.</li>
+            </ul>
+            <p className="text-gray-600">
+              These providers may process data outside Brazil. In such cases, the international
+              transfer takes place in accordance with articles 33 et seq. of the LGPD and the
+              ANPD&apos;s International Data Transfer Regulation (Resolution CD/ANPD No.
+              19/2024), based on standard contractual clauses or another safeguard admitted by
+              the regulation. We may also share data when required by law or by order of a
+              competent authority.
+            </p>
+          </section>
+
+          <section className="mb-8">
+            <h2 className="text-2xl font-semibold text-gray-900 mb-4">6. How long we keep it</h2>
+            <ul className="list-disc pl-6 text-gray-600 space-y-2">
+              <li>
+                <strong>Beta leads:</strong> kept for as long as the relationship about the beta
+                program lasts or until you request deletion;
+              </li>
+              <li>
+                <strong>Technical logs:</strong> retained for a short period by the hosting
+                infrastructure and discarded automatically;
+              </li>
+              <li>
+                <strong>Browsing events:</strong> stored anonymously, with no link to an
+                identifiable person.
+              </li>
+            </ul>
+          </section>
+
+          <section className="mb-8">
+            <h2 className="text-2xl font-semibold text-gray-900 mb-4">7. Your rights (LGPD)</h2>
+            <p className="text-gray-600 mb-4">
+              Under article 18 of the LGPD, you may request at any time:
+            </p>
+            <ul className="list-disc pl-6 text-gray-600 space-y-2 mb-4">
+              <li>Confirmation of processing and access to your data</li>
+              <li>Correction of incomplete, inaccurate or outdated data</li>
+              <li>Anonymization, blocking or deletion of unnecessary or excessive data</li>
+              <li>Portability of the data to another provider</li>
+              <li>Deletion of data processed on the basis of your consent</li>
+              <li>Information about with whom we share your data</li>
+              <li>Withdrawal of consent</li>
+            </ul>
+            <p className="text-gray-600">
+              To exercise any of these rights, write to{' '}
+              <a href="mailto:privacidade@fluxomind.com" className="text-blue-600 hover:underline">
+                privacidade@fluxomind.com
+              </a>
+              . We will respond within the timeframes established by law. You may also lodge a
+              complaint with the Brazilian National Data Protection Authority (ANPD).
+            </p>
+          </section>
+
+          <section className="mb-8">
+            <h2 className="text-2xl font-semibold text-gray-900 mb-4">8. Security</h2>
+            <p className="text-gray-600">
+              We adopt technical and organizational measures proportional to the risk: encrypted
+              traffic (HTTPS), restricted access to lead data, minimal data collection and abuse
+              protections on the forms. No system is infallible; in the event of a security
+              incident with relevant risk to data subjects, we will notify those affected and
+              the ANPD as required by the LGPD.
+            </p>
+          </section>
+
+          <section className="mb-8">
+            <h2 className="text-2xl font-semibold text-gray-900 mb-4">9. Children and teenagers</h2>
+            <p className="text-gray-600">
+              The Site is aimed at companies and professionals. We do not knowingly collect data
+              from anyone under 18. If you believe a minor has provided us personal data,
+              contact us so it can be removed.
+            </p>
+          </section>
+
+          <section className="mb-8">
+            <h2 className="text-2xl font-semibold text-gray-900 mb-4">10. Changes to this Policy</h2>
+            <p className="text-gray-600">
+              We may update this Policy to reflect changes on the Site or in legislation. The
+              last-updated date at the top of this page indicates the current version. Relevant
+              changes will be highlighted on the Site.
+            </p>
+          </section>
+
+          <section className="mb-8">
+            <h2 className="text-2xl font-semibold text-gray-900 mb-4">11. Contact</h2>
+            <p className="text-gray-600 mb-4">
+              For questions about this Policy or the processing of your personal data, use our
+              dedicated personal-data channel:
+            </p>
+            <div className="bg-gray-50 p-6 rounded-lg">
+              <p className="text-gray-700 font-semibold">FLUXOMIND LTDA</p>
+              <p className="text-gray-600">CNPJ: 60.162.547/0001-15</p>
+              <p className="text-gray-600">São Paulo/SP — Brazil</p>
+              <p className="text-gray-600">E-mail: privacidade@fluxomind.com</p>
+            </div>
+            <p className="text-gray-600 mt-4">
+              See also our{' '}
+              <Link href="/en/terms" className="text-blue-600 hover:underline">
+                Terms of Service
+              </Link>
+              .
+            </p>
+          </section>
+        </article>
+      </main>
+
+      <footer className="bg-gray-900 text-white py-8">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="flex flex-col md:flex-row justify-between items-center">
+            <Link href="/en" className="mb-4 md:mb-0">
+              <img src="/logoSVG/logo-dark.svg" alt="Fluxomind" className="h-8 w-auto" />
+            </Link>
+            <div className="text-center md:text-right">
+              <p className="text-gray-400">&copy; {currentYear} Fluxomind &mdash; All rights reserved.</p>
+              <p className="text-gray-500 text-sm mt-2">FLUXOMIND LTDA &mdash; CNPJ: 60.162.547/0001-15</p>
+            </div>
+          </div>
+        </div>
+      </footer>
+    </div>
+  );
+}

--- a/src/app/en/terms/page.tsx
+++ b/src/app/en/terms/page.tsx
@@ -1,0 +1,284 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+
+export const metadata: Metadata = {
+  title: 'Terms of Service',
+  description: 'Terms of Service of Fluxomind (courtesy translation — the Portuguese version prevails)',
+  alternates: {
+    canonical: '/en/terms',
+    languages: { 'pt-BR': '/terms', en: '/en/terms' },
+  },
+};
+
+// Tradução de cortesia de /terms (ADR-0006, onda legal). A versão pt é a
+// juridicamente vinculante — nota de precedência no topo, padrão de mercado.
+export default function TermsEn() {
+  const currentYear = new Date().getFullYear();
+  const lastUpdated = 'July 4, 2026';
+
+  return (
+    <div className="min-h-screen bg-white" lang="en">
+      <header className="bg-white shadow-sm border-b border-gray-100">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="flex justify-between items-center py-4">
+            <Link href="/en" className="flex items-center">
+              <img src="/logoSVG/logo-light.svg" alt="Fluxomind" className="h-8 w-auto" />
+            </Link>
+            <Link href="/terms" className="text-gray-600 hover:text-gray-900 transition-colors" lang="pt-BR">
+              Versão em português →
+            </Link>
+          </div>
+        </div>
+      </header>
+
+      <main className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+        <article className="prose prose-gray max-w-none">
+          <h1 className="text-3xl md:text-4xl font-bold text-gray-900 mb-4">Terms of Service</h1>
+          <p className="text-gray-500 mb-4">Last updated: {lastUpdated}</p>
+          <div className="bg-blue-50 border border-blue-200 rounded-lg p-4 mb-8">
+            <p className="text-gray-700 text-sm">
+              This is a courtesy translation. In case of any conflict or divergence, the{' '}
+              <Link href="/terms" className="text-blue-600 hover:underline">
+                Portuguese version (Termos de Uso)
+              </Link>{' '}
+              prevails and is the legally binding one. FLUXOMIND LTDA is a Brazilian company and
+              these terms are governed by Brazilian law.
+            </p>
+          </div>
+
+          <section className="mb-8">
+            <h2 className="text-2xl font-semibold text-gray-900 mb-4">1. Acceptance of the Terms</h2>
+            <p className="text-gray-600 mb-4">
+              By accessing or using Fluxomind&apos;s services (&quot;Services&quot;), including our
+              platform, applications, APIs and messaging integrations (including WhatsApp
+              Business), you agree to be bound by these Terms of Service (&quot;Terms&quot;). If
+              you do not agree with these Terms, do not use our Services.
+            </p>
+            <p className="text-gray-600">
+              These Terms are a legal agreement between you and FLUXOMIND LTDA, enrolled with the
+              Brazilian corporate taxpayer registry (CNPJ) under No. 60.162.547/0001-15,
+              headquartered in São Paulo/SP, Brazil (&quot;Fluxomind&quot;, &quot;we&quot;,
+              &quot;us&quot; or &quot;our&quot;).
+            </p>
+          </section>
+
+          <section className="mb-8">
+            <h2 className="text-2xl font-semibold text-gray-900 mb-4">2. Description of the Services</h2>
+            <p className="text-gray-600 mb-4">Fluxomind offers an AI and automation platform that enables:</p>
+            <ul className="list-disc pl-6 text-gray-600 space-y-2 mb-4">
+              <li>Creation and management of intelligent automations</li>
+              <li>Integration with communication channels, including WhatsApp Business</li>
+              <li>Development of chatbots and virtual assistants</li>
+              <li>Data analysis and insight generation</li>
+              <li>Business process automation</li>
+            </ul>
+          </section>
+
+          <section className="mb-8">
+            <h2 className="text-2xl font-semibold text-gray-900 mb-4">3. Eligibility</h2>
+            <p className="text-gray-600 mb-4">To use our Services, you must:</p>
+            <ul className="list-disc pl-6 text-gray-600 space-y-2">
+              <li>Be at least 18 years old</li>
+              <li>Have the legal capacity to enter into binding contracts</li>
+              <li>Not be barred from receiving services under applicable law</li>
+              <li>Represent a duly constituted company or legal entity, where applicable</li>
+            </ul>
+          </section>
+
+          <section className="mb-8">
+            <h2 className="text-2xl font-semibold text-gray-900 mb-4">4. User Account</h2>
+            <p className="text-gray-600 mb-4">
+              To access certain features of the Services, you will need to create an account. You
+              are responsible for:
+            </p>
+            <ul className="list-disc pl-6 text-gray-600 space-y-2 mb-4">
+              <li>Keeping your access credentials confidential</li>
+              <li>All activity carried out under your account</li>
+              <li>Notifying us immediately of any unauthorized use</li>
+              <li>Providing accurate and up-to-date information</li>
+            </ul>
+          </section>
+
+          <section className="mb-8">
+            <h2 className="text-2xl font-semibold text-gray-900 mb-4">5. Messaging and WhatsApp Business</h2>
+            <p className="text-gray-600 mb-4">
+              By using our messaging Services, including the WhatsApp Business integration, you
+              agree to:
+            </p>
+            <ul className="list-disc pl-6 text-gray-600 space-y-2 mb-4">
+              <li>
+                <strong>Obtain consent:</strong> ensure you have the recipients&apos; explicit
+                opt-in before sending messages
+              </li>
+              <li>
+                <strong>Respect preferences:</strong> honor opt-out requests immediately
+              </li>
+              <li>
+                <strong>Permitted content:</strong> not send spam or illegal, fraudulent,
+                misleading or offensive content
+              </li>
+              <li>
+                <strong>Appropriate frequency:</strong> not send excessive messages or at
+                inappropriate times
+              </li>
+              <li>
+                <strong>Clear identification:</strong> clearly identify your company in all
+                communications
+              </li>
+            </ul>
+            <p className="text-gray-600">
+              You also agree to comply with Meta/WhatsApp policies, including the{' '}
+              <a href="https://business.whatsapp.com/policy" target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:underline">WhatsApp Business Messaging Policy</a>{' '}
+              and the{' '}
+              <a href="https://www.whatsapp.com/legal/business-terms" target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:underline">WhatsApp Business Terms of Service</a>.
+            </p>
+          </section>
+
+          <section className="mb-8">
+            <h2 className="text-2xl font-semibold text-gray-900 mb-4">6. Acceptable Use</h2>
+            <p className="text-gray-600 mb-4">You agree not to use the Services to:</p>
+            <ul className="list-disc pl-6 text-gray-600 space-y-2">
+              <li>Violate applicable laws or regulations</li>
+              <li>Infringe third-party intellectual property rights</li>
+              <li>Transmit viruses, malware or malicious code</li>
+              <li>Collect user data without consent</li>
+              <li>Reverse-engineer or decompile the software</li>
+              <li>Overload or interfere with the Services&apos; infrastructure</li>
+              <li>Create fake accounts or impersonate others</li>
+              <li>Send unsolicited communications or spam</li>
+              <li>Promote illegal, discriminatory or harmful activities</li>
+            </ul>
+          </section>
+
+          <section className="mb-8">
+            <h2 className="text-2xl font-semibold text-gray-900 mb-4">7. Intellectual Property</h2>
+            <p className="text-gray-600 mb-4">
+              All intellectual property rights related to the Services, including software,
+              design, trademarks and content, belong to Fluxomind or its licensors. You receive a
+              limited, non-exclusive, non-transferable license to use the Services under these
+              Terms.
+            </p>
+            <p className="text-gray-600">
+              You retain ownership of all content you create or upload through the Services,
+              granting Fluxomind a license to process and display such content as necessary to
+              provide the Services.
+            </p>
+          </section>
+
+          <section className="mb-8">
+            <h2 className="text-2xl font-semibold text-gray-900 mb-4">8. Privacy and Data Protection</h2>
+            <p className="text-gray-600 mb-4">
+              The processing of your personal data is governed by our{' '}
+              <Link href="/en/privacy" className="text-blue-600 hover:underline">Privacy Policy</Link>.
+              By using the Services, you agree to the collection and use of data as described in
+              the Privacy Policy.
+            </p>
+            <p className="text-gray-600">
+              Fluxomind is committed to compliance with the Brazilian General Data Protection Law
+              (LGPD) and other applicable data protection legislation.
+            </p>
+          </section>
+
+          <section className="mb-8">
+            <h2 className="text-2xl font-semibold text-gray-900 mb-4">9. Payments and Subscriptions</h2>
+            <p className="text-gray-600 mb-4">
+              Some Services may require payment. By purchasing paid Services, you agree to:
+            </p>
+            <ul className="list-disc pl-6 text-gray-600 space-y-2">
+              <li>Provide accurate and up-to-date payment information</li>
+              <li>Pay all applicable fees when due</li>
+              <li>Automatic renewal of subscriptions unless cancelled in advance</li>
+              <li>Price changes upon 30 days&apos; prior notice</li>
+            </ul>
+          </section>
+
+          <section className="mb-8">
+            <h2 className="text-2xl font-semibold text-gray-900 mb-4">10. Limitation of Liability</h2>
+            <p className="text-gray-600 mb-4">To the maximum extent permitted by law:</p>
+            <ul className="list-disc pl-6 text-gray-600 space-y-2 mb-4">
+              <li>The Services are provided &quot;as is&quot;, without warranties of any kind</li>
+              <li>Fluxomind shall not be liable for indirect, incidental, special or consequential damages</li>
+              <li>Our total liability shall not exceed the amount you paid in the last 12 months</li>
+            </ul>
+          </section>
+
+          <section className="mb-8">
+            <h2 className="text-2xl font-semibold text-gray-900 mb-4">11. Indemnification</h2>
+            <p className="text-gray-600">
+              You agree to indemnify and hold harmless Fluxomind, its officers, employees and
+              partners from any claims, losses or damages arising from: (a) your use of the
+              Services; (b) violation of these Terms; (c) violation of third-party rights; or (d)
+              content you transmit through the Services.
+            </p>
+          </section>
+
+          <section className="mb-8">
+            <h2 className="text-2xl font-semibold text-gray-900 mb-4">12. Termination</h2>
+            <p className="text-gray-600 mb-4">
+              We may suspend or terminate your access to the Services at any time, with or
+              without cause, upon notice. You may close your account at any time through the
+              account settings or by contacting us.
+            </p>
+            <p className="text-gray-600">
+              Upon termination, your right to use the Services ceases immediately. Provisions
+              that by their nature should survive termination shall remain in force.
+            </p>
+          </section>
+
+          <section className="mb-8">
+            <h2 className="text-2xl font-semibold text-gray-900 mb-4">13. Changes</h2>
+            <p className="text-gray-600">
+              We reserve the right to modify these Terms at any time. Significant changes will be
+              communicated by e-mail or through the Services. Continued use of the Services after
+              the changes constitutes acceptance of the new Terms.
+            </p>
+          </section>
+
+          <section className="mb-8">
+            <h2 className="text-2xl font-semibold text-gray-900 mb-4">14. Governing Law and Venue</h2>
+            <p className="text-gray-600">
+              These Terms are governed by the laws of the Federative Republic of Brazil. Any
+              dispute shall be submitted to the courts of the district of São Paulo, SP, Brazil,
+              to the exclusion of any other, however privileged.
+            </p>
+          </section>
+
+          <section className="mb-8">
+            <h2 className="text-2xl font-semibold text-gray-900 mb-4">15. General Provisions</h2>
+            <ul className="list-disc pl-6 text-gray-600 space-y-2">
+              <li><strong>Entire agreement:</strong> these Terms constitute the entire agreement between you and Fluxomind</li>
+              <li><strong>Waiver:</strong> failure to exercise any right does not constitute a waiver of it</li>
+              <li><strong>Severability:</strong> if any provision is held invalid, the remaining ones remain in force</li>
+              <li><strong>Assignment:</strong> you may not assign your rights without our prior written consent</li>
+            </ul>
+          </section>
+
+          <section className="mb-8">
+            <h2 className="text-2xl font-semibold text-gray-900 mb-4">16. Contact</h2>
+            <p className="text-gray-600 mb-4">For questions about these Terms of Service, contact us:</p>
+            <div className="bg-gray-50 p-6 rounded-lg">
+              <p className="text-gray-700 font-semibold">FLUXOMIND LTDA</p>
+              <p className="text-gray-600">CNPJ: 60.162.547/0001-15</p>
+              <p className="text-gray-600">São Paulo/SP — Brazil</p>
+              <p className="text-gray-600">E-mail: contato@fluxomind.com</p>
+            </div>
+          </section>
+        </article>
+      </main>
+
+      <footer className="bg-gray-900 text-white py-8">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="flex flex-col md:flex-row justify-between items-center">
+            <Link href="/en" className="mb-4 md:mb-0">
+              <img src="/logoSVG/logo-dark.svg" alt="Fluxomind" className="h-8 w-auto" />
+            </Link>
+            <div className="text-center md:text-right">
+              <p className="text-gray-400">&copy; {currentYear} Fluxomind &mdash; All rights reserved.</p>
+              <p className="text-gray-500 text-sm mt-2">FLUXOMIND LTDA &mdash; CNPJ: 60.162.547/0001-15</p>
+            </div>
+          </div>
+        </div>
+      </footer>
+    </div>
+  );
+}

--- a/src/app/en/use-cases/[slug]/page.tsx
+++ b/src/app/en/use-cases/[slug]/page.tsx
@@ -1,19 +1,18 @@
 import Link from 'next/link';
 import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
-import SiteHeader from '@/components/SiteHeader';
-import SiteFooter from '@/components/SiteFooter';
-import { SIGNATURE, PHASE, CTA } from '@/lib/messages';
-import { CASOS, getCaso } from '@/lib/casos';
-import { CASO_EN_SLUG_BY_PT } from '@/lib/casos-en';
+import SiteHeaderEn from '@/components/SiteHeaderEn';
+import SiteFooterEn from '@/components/SiteFooterEn';
+import { SIGNATURE_EN, PHASE_EN, CTA_EN } from '@/lib/messages-en';
+import { PLATFORM_CONTACT_EN } from '@/lib/platform';
+import { CASOS_EN, getCasoEn } from '@/lib/casos-en';
 
-// Página de caso de uso — formato GEO: h1 como pergunta, primeira frase
-// definicional, seções autocontidas, FAQ visível espelhado em FAQPage
-// JSON-LD, data de atualização visível. O CTA primário leva à demo já no
-// cenário do caso (/demo?cenario=X — deep-link do PR #31).
+// Página de caso EN — espelho de /casos-de-uso/[slug] (formato GEO:
+// h1-pergunta, definição na 1ª frase, "The request, in plain words",
+// FAQ + FAQPage JSON-LD). CTA da demo leva ao cenário pt com moldura.
 
 export function generateStaticParams() {
-  return CASOS.map((c) => ({ slug: c.slug }));
+  return CASOS_EN.map((c) => ({ slug: c.slug }));
 }
 
 export async function generateMetadata({
@@ -21,28 +20,27 @@ export async function generateMetadata({
 }: {
   params: Promise<{ slug: string }>;
 }): Promise<Metadata> {
-  const caso = getCaso((await params).slug);
+  const caso = getCasoEn((await params).slug);
   if (!caso) return {};
-  const enSlug = CASO_EN_SLUG_BY_PT[caso.slug];
   return {
     title: caso.titleSeO,
     description: caso.descriptionSeO,
     alternates: {
-      canonical: `/casos-de-uso/${caso.slug}`,
+      canonical: `/en/use-cases/${caso.slug}`,
       languages: {
-        'pt-BR': `/casos-de-uso/${caso.slug}`,
-        ...(enSlug ? { en: `/en/use-cases/${enSlug}` } : {}),
+        'pt-BR': `/casos-de-uso/${caso.ptSlug}`,
+        en: `/en/use-cases/${caso.slug}`,
       },
     },
   };
 }
 
-export default async function CasoDeUsoPage({
+export default async function UseCasePageEn({
   params,
 }: {
   params: Promise<{ slug: string }>;
 }) {
-  const caso = getCaso((await params).slug);
+  const caso = getCasoEn((await params).slug);
   if (!caso) notFound();
 
   const faqJsonLd = {
@@ -56,32 +54,28 @@ export default async function CasoDeUsoPage({
   };
 
   return (
-    <div className="page-ent">
+    <div className="page-ent" lang="en">
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLd) }}
       />
-      <SiteHeader cta={{ label: CTA.demo, href: `/demo?cenario=${caso.cenario}` }} />
+      <SiteHeaderEn ptHref={`/casos-de-uso/${caso.ptSlug}`} />
 
       <header className="hero">
         <div className="wrap">
           <div>
-            <span className="pill">
-              Caso de uso · {caso.area}
-            </span>
+            <span className="pill">Use case · {caso.area}</span>
           </div>
-          <div className="kick" style={{ marginTop: 18 }}>{SIGNATURE}</div>
+          <div className="kick" style={{ marginTop: 18 }}>{SIGNATURE_EN}</div>
           <h1 style={{ maxWidth: '26ch' }}>{caso.h1}</h1>
-          {/* 1ª menção do termo linka a definição canônica (/app-operante) —
-              acoplado ao prefixo padrão das definições em casos.ts */}
           <p className="hsub">
-            {caso.definicao.startsWith('Um app operante') ? (
+            {caso.definicao.startsWith('A self-operating') ? (
               <>
-                Um{' '}
-                <Link href="/app-operante" style={{ textDecoration: 'underline' }}>
-                  app operante
+                A{' '}
+                <Link href="/en/self-operating-app" style={{ textDecoration: 'underline' }}>
+                  self-operating
                 </Link>
-                {caso.definicao.slice('Um app operante'.length)}
+                {caso.definicao.slice('A self-operating'.length)}
               </>
             ) : (
               caso.definicao
@@ -91,22 +85,22 @@ export default async function CasoDeUsoPage({
             <Link
               className="btn btn-primary"
               href={`/demo?cenario=${caso.cenario}`}
-              data-track={`caso-${caso.slug}-demo-cta`}
+              data-track={`en-case-${caso.slug}-demo-cta`}
             >
-              Veja este caso ao vivo — {CTA.demo.toLowerCase()}
+              See this case live — {CTA_EN.demo.toLowerCase()}
             </Link>
-            <a className="btn btn-ghost" href="#como">
-              Como funciona
+            <a className="btn btn-ghost" href="#how">
+              How it works
             </a>
           </div>
+          <p style={{ marginTop: 10, fontSize: 13.5, color: 'var(--slate)' }}>{CTA_EN.demoNote}</p>
         </div>
       </header>
 
-      {/* HOJE — a dor, nomeada */}
-      <section id="hoje" style={{ paddingTop: 0 }}>
+      <section id="today" style={{ paddingTop: 0 }}>
         <div className="wrap">
           <div className="center">
-            <div className="kick">O problema</div>
+            <div className="kick">The problem</div>
             <h2>{caso.hoje.titulo}</h2>
           </div>
           <div className="faq" style={{ marginTop: 26 }}>
@@ -120,15 +114,14 @@ export default async function CasoDeUsoPage({
         </div>
       </section>
 
-      {/* O PEDIDO, EM PORTUGUÊS — o prompt de autoria do UC (§2 do package),
-          exibido como citação: o visitante lê alguém como ele pedindo o app */}
+      {/* THE REQUEST, IN PLAIN WORDS */}
       <section style={{ paddingTop: 0 }}>
         <div className="wrap">
           <div className="center">
-            <div className="kick">O pedido, em português</div>
-            <h2>É assim que esse app nasce: alguém descreve o problema</h2>
+            <div className="kick">The request, in plain words</div>
+            <h2>This is how the app is born: someone describes the problem</h2>
             <p className="lead" style={{ marginTop: 14 }}>
-              Um pedido real, do jeito que um dono de negócio escreve — sem menu, sem código:
+              A real request, the way a business owner writes it — no menus, no code:
             </p>
           </div>
           <blockquote
@@ -136,7 +129,6 @@ export default async function CasoDeUsoPage({
               maxWidth: 760,
               margin: '28px auto 0',
               padding: '24px 28px',
-              borderLeft: '3px solid var(--blue)',
               border: '1px solid var(--line)',
               borderLeftWidth: 3,
               borderLeftColor: 'var(--blue)',
@@ -155,20 +147,19 @@ export default async function CasoDeUsoPage({
           <p style={{ textAlign: 'center', marginTop: 18 }}>
             <Link
               href={`/demo?cenario=${caso.cenario}`}
-              data-track={`caso-${caso.slug}-pedido-demo-cta`}
+              data-track={`en-case-${caso.slug}-request-demo-cta`}
               style={{ textDecoration: 'underline' }}
             >
-              Veja um pedido assim virar app, na sua frente →
+              Watch a request like this become an app, in front of you →
             </Link>
           </p>
         </div>
       </section>
 
-      {/* COM UM APP OPERANTE — o que roda sozinho */}
-      <section id="como" style={{ paddingTop: 0 }}>
+      <section id="how" style={{ paddingTop: 0 }}>
         <div className="wrap">
           <div className="center">
-            <div className="kick">Com um app operante</div>
+            <div className="kick">With a self-operating app</div>
             <h2>{caso.comApp.titulo}</h2>
           </div>
           <div className="ways">
@@ -182,15 +173,14 @@ export default async function CasoDeUsoPage({
         </div>
       </section>
 
-      {/* ONDE UM HUMANO ASSUME */}
       <section style={{ paddingTop: 0 }}>
         <div className="wrap">
           <div className="fit">
             <div className="kick" style={{ color: 'var(--sky)' }}>
-              Onde um humano assume
+              Where a human takes over
             </div>
             <h2 style={{ color: '#fff', maxWidth: '26ch' }}>
-              O app opera o dia a dia. Nos casos sensíveis, uma pessoa decide.
+              The app runs the day-to-day. In the sensitive cases, a person decides.
             </h2>
             <p style={{ marginTop: 18, fontSize: 17, color: '#A9AEB8', maxWidth: '62ch', lineHeight: 1.6 }}>
               {caso.humano}
@@ -199,12 +189,11 @@ export default async function CasoDeUsoPage({
         </div>
       </section>
 
-      {/* FAQ — visível + JSON-LD */}
       <section id="faq" style={{ paddingTop: 0 }}>
         <div className="wrap">
           <div className="center">
-            <div className="kick">Dúvidas comuns</div>
-            <h2>O que costumam perguntar sobre este caso</h2>
+            <div className="kick">Common questions</div>
+            <h2>What people ask about this case</h2>
           </div>
           <div className="faq">
             {caso.faq.map((f) => (
@@ -217,55 +206,52 @@ export default async function CasoDeUsoPage({
         </div>
       </section>
 
-      {/* TRANSPARÊNCIA DE FASE */}
       <section style={{ paddingTop: 0 }}>
         <div className="wrap">
           <div className="honest">
-            <b>Transparência.</b> A demonstração deste caso usa dados de exemplo — o app real
-            nasce dentro da plataforma, com os seus dados. {PHASE.exists.title}:{' '}
-            {PHASE.exists.desc} Estamos em beta: a adoção acontece acompanhada de perto pelo
-            nosso time, em semanas — não num projeto de meses.
+            <b>Transparency.</b> The demo of this case uses sample data and runs in Portuguese —
+            the real app is born inside the platform, with your data. {PHASE_EN.exists} We are
+            in beta: adoption happens closely accompanied by our team, in weeks — not a
+            months-long project.
           </div>
           <p style={{ textAlign: 'center', marginTop: 14, fontSize: 13.5, color: 'var(--slate)' }}>
-            Atualizado em {caso.atualizado} ·{' '}
-            <Link href="/casos-de-uso">todos os casos de uso</Link>
+            Updated {caso.atualizado} · <Link href="/en/use-cases">all use cases</Link>
           </p>
         </div>
       </section>
 
-      {/* CTA FINAL */}
       <section style={{ paddingTop: 0 }}>
         <div className="wrap">
           <div className="cta-card">
             <div className="kick" style={{ color: 'var(--sky)' }}>
-              Viva este caso agora
+              Live this case now
             </div>
-            <h2>Veja o app nascer da planilha — e opere você</h2>
+            <h2>Watch the app be born from a spreadsheet — and operate it yourself</h2>
             <p className="lead">
-              A demonstração interativa abre já neste caso: o app se constrói na sua frente,
-              você opera o processo e aprova o que vê.
+              The interactive demo opens right on this case: the app builds itself in front of
+              you, you operate the process and approve what you see. {CTA_EN.demoNote}.
             </p>
             <div className="ctab">
               <Link
                 className="btn btn-primary"
                 href={`/demo?cenario=${caso.cenario}`}
-                data-track={`caso-${caso.slug}-demo-cta`}
+                data-track={`en-case-${caso.slug}-demo-cta`}
               >
-                {CTA.demo}
+                {CTA_EN.demo}
               </Link>
-              <Link
+              <a
                 className="btn btn-ghost"
-                href="/#comecar"
-                data-track={`caso-${caso.slug}-beta-cta`}
+                href={PLATFORM_CONTACT_EN}
+                data-track={`en-case-${caso.slug}-contact-cta`}
               >
-                {CTA.beta}
-              </Link>
+                {CTA_EN.contact}
+              </a>
             </div>
           </div>
         </div>
       </section>
 
-      <SiteFooter tagline={SIGNATURE} />
+      <SiteFooterEn />
     </div>
   );
 }

--- a/src/app/en/use-cases/page.tsx
+++ b/src/app/en/use-cases/page.tsx
@@ -1,0 +1,104 @@
+import Link from 'next/link';
+import type { Metadata } from 'next';
+import SiteHeaderEn from '@/components/SiteHeaderEn';
+import SiteFooterEn from '@/components/SiteFooterEn';
+import { SIGNATURE_EN, PHASE_EN, CTA_EN } from '@/lib/messages-en';
+import { PLATFORM_CONTACT_EN } from '@/lib/platform';
+import { CASOS_EN } from '@/lib/casos-en';
+
+export const metadata: Metadata = {
+  title: 'Use cases — what a self-operating app resolves in your business',
+  description:
+    'Fluxomind use cases by business process: lead management, collections and accounts receivable, WhatsApp support. Each case shows what runs on its own, where a human decides — and you can live the case in the interactive demo.',
+  alternates: {
+    canonical: '/en/use-cases',
+    languages: { 'pt-BR': '/casos-de-uso', en: '/en/use-cases' },
+  },
+};
+
+// Hub EN de casos de uso — espelho de /casos-de-uso (ADR-0005/0006).
+export default function UseCasesEn() {
+  return (
+    <div className="page-ent" lang="en">
+      <SiteHeaderEn ptHref="/casos-de-uso" />
+
+      <header className="hero">
+        <div className="wrap">
+          <div>
+            <span className="pill">Use cases · by business process</span>
+          </div>
+          <div className="kick" style={{ marginTop: 18 }}>{SIGNATURE_EN}</div>
+          <h1 style={{ maxWidth: '24ch' }}>
+            Which process do you want <span className="g">off your back?</span>
+          </h1>
+          <p className="hsub">
+            A <Link href="/en/self-operating-app" style={{ textDecoration: 'underline' }}>self-operating app</Link>{' '}
+            builds itself from your problem — your spreadsheet really comes in — and starts
+            running the day-to-day of that process, handing off to a person in the cases that
+            require a decision. These are the cases you can{' '}
+            <strong>live right now in the demo</strong>, with sample data:
+          </p>
+        </div>
+      </header>
+
+      <section id="cases" style={{ paddingTop: 0 }}>
+        <div className="wrap">
+          <div className="prob">
+            {CASOS_EN.map((c) => (
+              <Link
+                key={c.slug}
+                href={`/en/use-cases/${c.slug}`}
+                className="pcard"
+                data-track={`en-cases-hub-${c.slug}`}
+                style={{ display: 'block' }}
+              >
+                <div className="pi" aria-hidden="true" style={{ fontSize: 26, lineHeight: 1 }}>
+                  {c.emoji}
+                </div>
+                <div className="tagm" style={{ marginTop: 10 }}>{c.area}</div>
+                <h3 style={{ marginTop: 8 }}>{c.h1}</h3>
+                <p>“{c.dorHook}” The full case — and the live demo — here →</p>
+              </Link>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section style={{ paddingTop: 0 }}>
+        <div className="wrap">
+          <div className="honest">
+            <b>Transparency.</b> The three cases above are the ones the interactive demo covers
+            today, with sample data — the demo runs in Portuguese. {PHASE_EN.exists} Your
+            process is not on the list? Tell us which one — in the beta, the first
+            self-operating app is born from <em>your</em> problem, accompanied by our team.
+          </div>
+        </div>
+      </section>
+
+      <section style={{ paddingTop: 0 }}>
+        <div className="wrap">
+          <div className="cta-card">
+            <div className="kick" style={{ color: 'var(--sky)' }}>
+              Start with a pain
+            </div>
+            <h2>Pick a case — or bring your own</h2>
+            <p className="lead">
+              Every case above ends in the interactive demo: you watch the app be born from a
+              spreadsheet, operate the process and approve what you see. {CTA_EN.demoNote}.
+            </p>
+            <div className="ctab">
+              <Link className="btn btn-primary" href="/demo" data-track="en-cases-hub-demo-cta">
+                {CTA_EN.demo}
+              </Link>
+              <a className="btn btn-ghost" href={PLATFORM_CONTACT_EN} data-track="en-cases-hub-contact-cta">
+                {CTA_EN.contact}
+              </a>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <SiteFooterEn />
+    </div>
+  );
+}

--- a/src/app/en/why/page.tsx
+++ b/src/app/en/why/page.tsx
@@ -1,0 +1,202 @@
+import Link from 'next/link';
+import type { Metadata } from 'next';
+import SiteHeaderEn from '@/components/SiteHeaderEn';
+import SiteFooterEn from '@/components/SiteFooterEn';
+import { PURPOSE_LINE_EN, CTA_EN } from '@/lib/messages-en';
+import { PLATFORM_CONTACT_EN } from '@/lib/platform';
+
+export const metadata: Metadata = {
+  title: 'Why',
+  description: `${PURPOSE_LINE_EN} In the founder's own words.`,
+  alternates: {
+    canonical: '/en/why',
+    languages: { 'pt-BR': '/por-que', en: '/en/why' },
+  },
+};
+
+// Espelho EN de /por-que (ADR-0006). Texto assinado: tradução fiel à carta
+// pt, marcada para reescrita do fundador no seu próprio inglês — a voz
+// pessoal é dele. 3 atos; a visão declarada como aposta, nunca fato.
+export default function WhyEn() {
+  return (
+    <div className="page-porque" lang="en">
+      <style>{PQ_CSS}</style>
+
+      <SiteHeaderEn ptHref="/por-que" />
+
+      <header className="hero">
+        <div className="wrap pq-hero">
+          <span className="pill">Why we exist · in the founder&apos;s words</span>
+          <h1>
+            For 30 years, companies <span className="g">adapted to their software.</span>
+          </h1>
+          <p className="hsub">
+            It is time for software to mold itself to them — and work for them. That is what
+            Fluxomind exists for.
+          </p>
+        </div>
+      </header>
+
+      <section className="pq-act">
+        <div className="wrap pq-prose">
+          <div className="kick">Act 1 · The old way</div>
+          <h2>Who has never bent a process to fit a system?</h2>
+          <p>
+            There were always two paths. You buy a ready-made system and start working its way —
+            the fields it has, the screens it chose, the report it gives. Or you pay for a
+            project to bend it to your process: months of implementation, a consulting budget —
+            and, every time the business changes, all of it again.
+          </p>
+          <p>
+            On both paths, the result is the same: <strong>the software stands still</strong>.
+            The one chasing — typing, cross-checking spreadsheets, collecting, verifying,
+            remembering — is you and your team. The tool stores the data; the work is still
+            yours.
+          </p>
+          <blockquote className="pq-pull">
+            Tailor-made technology always existed. But it was a privilege: a project, an
+            integrator, an IT team. Whoever couldn&apos;t pay made do with spreadsheets.
+          </blockquote>
+        </div>
+      </section>
+
+      <section className="pq-act pq-dark">
+        <div className="wrap pq-prose">
+          <div className="kick" style={{ color: 'var(--sky)' }}>
+            Act 2 · The inversion
+          </div>
+          <h2 style={{ color: '#fff' }}>
+            For the first time, software can mold itself to the business — and work for it.
+          </h2>
+          <p>
+            AI crossed two thresholds that change this story. It started to{' '}
+            <strong>understand context</strong> — what used to require a project to adapt now
+            happens from what you describe. And it started to <strong>execute</strong> — what
+            was always a person chasing, an agent now does, shows the proof, and calls you on
+            what is sensitive.
+          </p>
+          <p>
+            That creates a new category. Not a system you operate: an app that builds itself
+            from your problem and <strong>runs the day-to-day</strong> — integrated with what
+            you already have, governed, in weeks.
+          </p>
+          <div className="pq-purpose">
+            <div className="pq-purpose-label">Our why</div>
+            <p>
+              We exist to give any business what used to be the privilege of those who could
+              pay for it: <strong>a tailor-made system, operated and governed</strong> — without
+              a months-long project, without an IT team, without bending your process to fit
+              the tool.
+            </p>
+          </div>
+          <p>
+            That is why our home page is a demonstration, not a promise. Delegating an
+            operation takes trust — and trust, around here, is earned with proof on screen.
+          </p>
+        </div>
+      </section>
+
+      <section className="pq-act">
+        <div className="wrap pq-prose">
+          <div className="kick">Act 3 · The bet</div>
+          <h2>Where we believe this is going</h2>
+          <p>
+            The knowledge of how to solve a problem — the method an expert spent years honing —
+            is today trapped in one person&apos;s calendar. It serves one client at a time, and
+            never reaches everyone who needs it.
+          </p>
+          <p>
+            Our bet, declared as a bet: that knowledge will become a{' '}
+            <strong>living software business</strong> — created by whoever masters the problem,
+            adopted already operated by whoever needs the solution. The next generation of
+            systems won&apos;t be bought off the shelf nor cost a project: it will be born from
+            those who know the subject, and work inside the business of those who adopt it.
+          </p>
+          <p>
+            We are not there yet — and we prefer to tell you exactly that. What already exists,
+            what comes next and what is vision are always kept apart, here and across{' '}
+            <Link href="/en" className="pq-link">
+              the whole site
+            </Link>
+            .
+          </p>
+
+          <div className="pq-sign">
+            <div className="pq-sign-name">Ralfo Nunes</div>
+            <div className="pq-sign-role">founder · July 2026</div>
+          </div>
+        </div>
+      </section>
+
+      <section className="offer">
+        <div className="wrap">
+          <div className="kick" style={{ color: 'var(--sky)' }}>
+            The next step
+          </div>
+          <h2>The best way to understand is to watch it work</h2>
+          <p className="lead" style={{ maxWidth: '56ch', margin: '14px auto 0' }}>
+            {PURPOSE_LINE_EN}
+          </p>
+          <div className="offerbtns">
+            <Link className="btn btn-primary btn-lg" href="/demo" data-track="en-why-demo-cta">
+              {CTA_EN.demo}
+            </Link>
+            <a className="btn btn-ghost btn-lg" href={PLATFORM_CONTACT_EN} data-track="en-why-contact-cta">
+              {CTA_EN.contact}
+            </a>
+          </div>
+          <p style={{ marginTop: 10, fontSize: 13.5, color: 'var(--slate)' }}>{CTA_EN.demoNote}</p>
+        </div>
+      </section>
+
+      <SiteFooterEn />
+    </div>
+  );
+}
+
+const PQ_CSS = `
+.page-porque .pq-hero { text-align: center; padding-bottom: 40px; }
+.page-porque .pq-hero h1 { max-width: 22ch; margin: 0 auto; }
+.page-porque .pq-hero .hsub { max-width: 58ch; margin: 18px auto 0; }
+.pq-act { padding: 72px 0; }
+.pq-act.pq-dark {
+  background:
+    radial-gradient(900px 420px at 50% 0%, rgba(43, 102, 221, 0.22), transparent 60%),
+    var(--ink);
+  color: #cdd3dc;
+}
+.pq-prose { max-width: 680px; margin: 0 auto; }
+.pq-prose h2 { margin-top: 14px; }
+.pq-prose p { margin-top: 18px; font-size: 17px; line-height: 1.75; }
+.pq-dark .pq-prose p { color: #b6bdc9; }
+.pq-dark .pq-prose strong { color: #fff; }
+.pq-pull {
+  margin: 30px 0 6px;
+  padding: 4px 0 4px 22px;
+  border-left: 3px solid var(--blue);
+  font-size: 19px;
+  line-height: 1.6;
+  font-weight: 550;
+  color: var(--slate);
+}
+.pq-purpose {
+  margin: 30px 0 6px;
+  padding: 24px 26px;
+  border: 1px solid rgba(77, 171, 247, 0.35);
+  border-radius: 14px;
+  background: rgba(43, 102, 221, 0.10);
+}
+.pq-purpose .pq-purpose-label {
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+  color: var(--sky);
+}
+.pq-purpose p { margin-top: 10px; font-size: 17.5px; color: #e8ecf3; }
+.pq-link { color: var(--blue); font-weight: 600; }
+.pq-dark .pq-link { color: var(--sky); }
+.pq-sign { margin-top: 44px; padding-top: 22px; border-top: 1px solid var(--line); }
+.pq-sign-name { font-size: 18px; font-weight: 700; }
+.pq-sign-role { margin-top: 2px; font-size: 14px; color: var(--mute); }
+`;

--- a/src/app/por-que/page.tsx
+++ b/src/app/por-que/page.tsx
@@ -7,6 +7,10 @@ import { SIGNATURE, PURPOSE_LINE, CTA } from '@/lib/messages';
 export const metadata: Metadata = {
   title: 'Por quê',
   description: `${PURPOSE_LINE} Na palavra de quem fundou.`,
+  alternates: {
+    canonical: '/por-que',
+    languages: { 'pt-BR': '/por-que', en: '/en/why' },
+  },
 };
 
 // Ensaio de propósito (message house §1.5): 3 atos, assinado pelo fundador,

--- a/src/app/privacidade/page.tsx
+++ b/src/app/privacidade/page.tsx
@@ -4,6 +4,10 @@ import Link from 'next/link';
 export const metadata: Metadata = {
   title: 'Política de Privacidade',
   description: 'Política de Privacidade da Fluxomind — como coletamos, usamos e protegemos seus dados pessoais (LGPD)',
+  alternates: {
+    canonical: '/privacidade',
+    languages: { 'pt-BR': '/privacidade', en: '/en/privacy' },
+  },
 };
 
 export default function PrivacyPolicy() {

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -26,6 +26,13 @@ export default function sitemap(): MetadataRoute.Sitemap {
     { url: `${BASE_URL}/en/security`, changeFrequency: 'monthly', priority: 0.5 },
     { url: `${BASE_URL}/en/accelerate`, changeFrequency: 'monthly', priority: 0.5 },
     { url: `${BASE_URL}/en/platform`, changeFrequency: 'monthly', priority: 0.5 },
+    { url: `${BASE_URL}/en/why`, changeFrequency: 'monthly', priority: 0.5 },
+    { url: `${BASE_URL}/en/use-cases`, changeFrequency: 'monthly', priority: 0.6 },
+    { url: `${BASE_URL}/en/use-cases/collections-and-accounts-receivable`, changeFrequency: 'monthly', priority: 0.5 },
+    { url: `${BASE_URL}/en/use-cases/lead-management`, changeFrequency: 'monthly', priority: 0.5 },
+    { url: `${BASE_URL}/en/use-cases/whatsapp-support`, changeFrequency: 'monthly', priority: 0.5 },
+    { url: `${BASE_URL}/en/terms`, changeFrequency: 'yearly', priority: 0.3 },
+    { url: `${BASE_URL}/en/privacy`, changeFrequency: 'yearly', priority: 0.3 },
     { url: `${BASE_URL}/terms`, changeFrequency: 'yearly', priority: 0.3 },
     { url: `${BASE_URL}/privacidade`, changeFrequency: 'yearly', priority: 0.3 },
   ];

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -4,6 +4,10 @@ import Link from 'next/link';
 export const metadata: Metadata = {
   title: 'Termos de Uso',
   description: 'Termos de Uso e Condições de Serviço da Fluxomind',
+  alternates: {
+    canonical: '/terms',
+    languages: { 'pt-BR': '/terms', en: '/en/terms' },
+  },
 };
 
 export default function TermsOfService() {

--- a/src/components/SiteFooterEn.tsx
+++ b/src/components/SiteFooterEn.tsx
@@ -14,14 +14,16 @@ export default function SiteFooterEn() {
         </div>
         <div style={{ display: 'flex', flexWrap: 'wrap', gap: 16, fontSize: 14 }}>
           <Link href="/en">English home</Link>
+          <Link href="/en/use-cases">Use cases</Link>
           <Link href="/en/self-operating-app">Self-operating app</Link>
+          <Link href="/en/why">Why</Link>
           <Link href="/en/what-it-does">What it does</Link>
           <Link href="/en/security">Security</Link>
           <Link href="/en/accelerate">Accelerate</Link>
           <Link href="/en/platform">Platform</Link>
           <Link href="/en/pricing">Pricing</Link>
-          <Link href="/terms" lang="pt-BR">Termos de Uso</Link>
-          <Link href="/privacidade" lang="pt-BR">Privacidade</Link>
+          <Link href="/en/terms">Terms</Link>
+          <Link href="/en/privacy">Privacy</Link>
           <Link href="/" lang="pt-BR">Português</Link>
         </div>
       </div>

--- a/src/components/SiteHeaderEn.tsx
+++ b/src/components/SiteHeaderEn.tsx
@@ -8,6 +8,7 @@ import { CTA_EN } from '@/lib/messages-en';
 // ADR-0006). Sem MobileNav por ora: ≤1040px os links colapsam via CSS e o
 // CTA permanece; menu hambúrguer EN entra quando o nav tiver mais itens.
 const NAV_EN = [
+  { href: '/en/use-cases', label: 'Use cases' },
   { href: '/en/self-operating-app', label: 'What it is' },
   { href: '/en/what-it-does', label: 'What it does' },
   { href: '/en/security', label: 'Security' },

--- a/src/lib/casos-en.ts
+++ b/src/lib/casos-en.ts
@@ -1,0 +1,224 @@
+// English use cases — mirror of casos.ts under docs/message-house-en.md
+// (ADR-0006: árvores paralelas). Slugs localizados para a busca EN.
+// ucIds/cenario idênticos ao pt (mesma fonte upstream: catálogo de UCs).
+
+export type CasoDeUsoEn = {
+  slug: string;
+  ptSlug: string; // par pt para hreflang e retorno de idioma
+  ucIds: string[];
+  cenario: 'leads' | 'caixa' | 'atendimento';
+  area: string;
+  dorHook: string;
+  pedido: string;
+  emoji: string;
+  titleSeO: string;
+  descriptionSeO: string;
+  h1: string;
+  definicao: string;
+  hoje: { titulo: string; itens: string[] };
+  comApp: { titulo: string; itens: { face: string; texto: string }[] };
+  humano: string;
+  faq: { q: string; a: string }[];
+  atualizado: string;
+};
+
+export const CASOS_EN: CasoDeUsoEn[] = [
+  {
+    slug: 'collections-and-accounts-receivable',
+    ptSlug: 'cobranca-e-contas-a-receber',
+    ucIds: ['UC-007', 'UC-022', 'UC-023'],
+    cenario: 'caixa',
+    area: 'Finance · collections',
+    dorHook: 'The due date passes and nobody notices in time.',
+    pedido: `I run a B2B services company with about 60 active customers. Invoices live in a spreadsheet (columns: customer, tax ID, amount, due date, status) and collection is by hand: when I remember, I send WhatsApp messages one by one. A customer falls behind and nobody notices in time; renegotiations have no history.
+
+I want to stop losing money to forgetfulness. I need my invoice and customer spreadsheet to really come in (no retyping) and the system to track due dates on its own. When a due date approaches or passes, I want it to compose the right message in the right tone for the stage (friendly reminder before → collection when late → renegotiation proposal if it drags) and show me the preview before sending — nothing goes out without my OK.
+
+Delicate cases — high amounts, strategic customers, discount or renegotiation requests — I don't want the system to resolve: I want it to prepare the case with the history ready and hand it to me to decide. And since it's money and my customer's tax ID, I want sensitive data protected and every action recorded, in a way I can undo if I make a mistake.`,
+    emoji: '💰',
+    titleSeO: 'Automate collections and accounts receivable — a self-operating finance app',
+    descriptionSeO:
+      'How to automate your collections cadence without an IT project: a self-operating app tracks due dates, composes the message in the right tone, shows the preview and sends only with your OK — with proof of every action.',
+    h1: 'How do you automate collections without losing control of what is sent?',
+    definicao:
+      'A self-operating collections app is an app that builds itself from your invoices and customers — the spreadsheet really comes in, with tax IDs protected — and starts running the collections cadence: it tracks due dates, composes the message in the right tone, shows the preview and sends only with your OK.',
+    hoje: {
+      titulo: 'Today: collecting depends on remembering — and on courage',
+      itens: [
+        'Invoices live in a spreadsheet; the due date passes and nobody notices in time.',
+        'Collecting means composing the right message, in the right tone, customer by customer.',
+        'The cadence (reminder, collection, renegotiation) exists — in theory. In practice, it is manual.',
+        'Without an organized history, every collection starts from zero.',
+      ],
+    },
+    comApp: {
+      titulo: 'With a self-operating app: the cadence runs — and nothing goes out without you',
+      itens: [
+        { face: 'Domain', texto: 'Invoices and customers come in from your spreadsheet; sensitive data like tax IDs is detected and protected from day one.' },
+        { face: 'Process', texto: 'Due dates are tracked on their own: a delay generates the collection proposal at the right stage of the cadence.' },
+        { face: 'Experience', texto: 'You see the preview of every message first — firm or cordial tone, you choose — and approve on screen.' },
+        { face: 'Trust', texto: 'Sending only with your OK, and every action is recorded with the proof. Mistakes don’t hurt: you can fix and undo.' },
+      ],
+    },
+    humano:
+      'Delicate customer, discount, renegotiation, high amount: the app doesn’t decide — it prepares the case with the full history and hands it to a person on your team.',
+    faq: [
+      {
+        q: 'Does the app collect from my customers on its own?',
+        a: 'Not without you. The day-to-day — tracking due dates, composing the message at the right stage — runs on its own; sending happens with your OK, with a preview on screen. Sensitive cases escalate to a person.',
+      },
+      {
+        q: 'Will it embarrass my customer or collect from the wrong person?',
+        a: 'No. You approve every message before it goes out and choose the tone; delicate cases — high amounts, strategic customers — come to you to decide, with the history ready.',
+      },
+      {
+        q: 'Does it reconcile payments? Does it work with my ERP?',
+        a: 'The app is born from your invoice spreadsheet and collects via WhatsApp and e-mail, coexisting with what you already use. In this version, payment reconciliation is yours; automatic reconciliation with bank or ERP is a planned evolution.',
+      },
+      {
+        q: 'What about my customers’ data?',
+        a: 'Your data, yours only: each company is truly isolated, sensitive data is protected and every action sits in a tamper-evident trail.',
+      },
+      {
+        q: 'How long until the cadence really runs?',
+        a: 'Weeks, not a months-long project. In the beta, the team accompanies you from design to the first collection you approve.',
+      },
+    ],
+    atualizado: 'July 2026',
+  },
+  {
+    slug: 'lead-management',
+    ptSlug: 'gestao-de-leads',
+    ucIds: ['UC-001', 'UC-002', 'UC-003'],
+    cenario: 'leads',
+    area: 'Sales · leads and contracts',
+    dorHook: 'My sales funnel lives in a spreadsheet and in my head — and stalled deals go cold with nobody noticing.',
+    pedido: `I run sales and need to organize how I win new customers. Today it is all manual: prospects arrive by referral, e-mail and social, I jot them in a spreadsheet (name, company, source, status, last conversation, next step) with about 50 rows, and I lose track.
+
+I want a system that manages my funnel end to end: every prospect becomes a living record, the funnel has clear stages (new → qualified → in conversation → proposal → closed) and I see on a board where each one is, with the history of every conversation kept.
+
+What kills me is the follow-through: I want the system to chase the follow-up of whoever went quiet on its own, warn me when a proposal has been stalled too long, and when I ask "which deals have stalled?" answer with the list and the suggested next step for each. Every message that goes out in my name I want to see and approve first — nothing fires on its own. Decision cases (out-of-policy discounts, strategic customers) should come to me with the history ready.`,
+    emoji: '📊',
+    titleSeO: 'Lead management without spreadsheets — a self-operating sales funnel app',
+    descriptionSeO:
+      'How to get leads and contracts out of the spreadsheet: a self-operating app records every lead, moves the funnel, chases follow-ups and warns when a proposal stalls — and hands you the cases that require a decision.',
+    h1: 'How do you stop managing leads and contracts in a spreadsheet?',
+    definicao:
+      'A self-operating lead management app is an app that builds itself from your sales funnel — your spreadsheet really comes in, no retyping — and starts running the day-to-day: it records the lead that arrives, moves the stages, chases the follow-up and warns when a proposal stalls.',
+    hoje: {
+      titulo: 'Today: the funnel lives in a spreadsheet — and in your head',
+      itens: [
+        'Leads arrive via WhatsApp, e-mail and referrals — and not all get recorded.',
+        'The spreadsheet is stale by the next day; nobody fully trusts it.',
+        'Follow-up depends on someone remembering. Stalled proposals go unnoticed.',
+        'At month’s end, assembling the funnel picture is hours of manual work.',
+      ],
+    },
+    comApp: {
+      titulo: 'With a self-operating app: the funnel runs — and you decide',
+      itens: [
+        { face: 'Domain', texto: 'Your lead and contract spreadsheet really comes in: columns become fields, every row becomes a living record.' },
+        { face: 'Process', texto: 'Follow-ups are scheduled and chased on their own; a stalled proposal raises a warning before it goes cold.' },
+        { face: 'Intelligence', texto: 'Ask "which deals have stalled?" and get the answer with proposed next steps.' },
+        { face: 'Trust', texto: 'Every conclusion arrives with the proof of what was done — nothing critical goes out without your OK.' },
+      ],
+    },
+    humano:
+      'Out-of-policy discount, sensitive negotiation, strategic customer: the app prepares the context and hands it to a person on your team — the AI proposes, whoever is in charge decides.',
+    faq: [
+      {
+        q: 'Do I need to replace my CRM or my spreadsheet?',
+        a: 'No. The app is born from your spreadsheet (it really comes in, no retyping) and coexists with what you already use — the operation integrates via e-mail, WhatsApp and API.',
+      },
+      {
+        q: 'Do I need to know how to code?',
+        a: 'No. You describe the problem in plain language; the app builds itself and, to change it, you talk.',
+      },
+      {
+        q: 'Does the app touch the funnel on its own?',
+        a: 'The day-to-day — recording, moving stages, chasing follow-ups — runs on its own. Sensitive actions go through you: the app proposes, shows the preview and executes only with your OK.',
+      },
+      {
+        q: 'What if I want to change my funnel stages later?',
+        a: 'You adjust by talking to the app — stages, alerts and fields change without depending on IT and without losing what is already recorded.',
+      },
+      {
+        q: 'How long until this runs in my company?',
+        a: 'Weeks, not a months-long project. In the beta, the Fluxomind team accompanies you from design to the first real conclusion.',
+      },
+    ],
+    atualizado: 'July 2026',
+  },
+  {
+    slug: 'whatsapp-support',
+    ptSlug: 'atendimento-whatsapp',
+    ucIds: ['UC-006', 'UC-027'],
+    cenario: 'atendimento',
+    area: 'Support · WhatsApp',
+    dorHook: 'My customers ask for everything on WhatsApp — booking, rescheduling, confirming — and one person answers it all day long.',
+    pedido: `My customers reach me on WhatsApp all the time for day-to-day things: booking a slot, rescheduling, confirming they will show up, or asking about the status of their order. Today a person on my team answers all of it by hand, which eats the day and still leaves people without a reply outside business hours.
+
+I want WhatsApp support to resolve these requests on its own, in the conversation, without the customer installing an app or creating a login. When someone writes "I'd like to book for Thursday", it should understand, check availability, offer slots and confirm — and the same for rescheduling and cancelling. Before appointments, I want it to send the attendance confirmation on its own and update the calendar according to the reply.
+
+On my side (internal), I want the calendar and records organized — each customer with their history, personal data protected, and a record of what was done in each conversation. When a customer complains, has an urgency or asks for something out of the ordinary, the support doesn't improvise: it hands the conversation to a person on my team with the full history, so the customer never has to repeat themselves.`,
+    emoji: '📅',
+    titleSeO: 'WhatsApp support that resolves — books, reschedules and confirms',
+    descriptionSeO:
+      'How to handle WhatsApp support without a person answering all day: a self-operating app understands the request and resolves it — books, reschedules, confirms attendance — and hands the conversation to your team in the sensitive cases.',
+    h1: 'How do you handle WhatsApp without someone answering messages all day?',
+    definicao:
+      'A self-operating support app is an app that answers on your WhatsApp and resolves the request — books, reschedules, confirms attendance, updates the record — instead of just replying. Not a chatbot that just replies: it is the support process running, with a person taking over when the case demands.',
+    hoje: {
+      titulo: 'Today: the calendar lives buried in messages',
+      itens: [
+        'One person answers everything — booking, rescheduling, confirmation — all day long.',
+        'Outside business hours, customers get no reply; by morning, the queue has piled up.',
+        'Reschedules get lost between conversations; no-shows go unprevented.',
+        'The customer’s history is scattered across WhatsApp threads.',
+      ],
+    },
+    comApp: {
+      titulo: 'With a self-operating app: the conversation becomes a resolved calendar',
+      itens: [
+        { face: 'Connections', texto: 'The app answers on the WhatsApp you already use — the customer changes nothing on their side.' },
+        { face: 'Process', texto: 'Booking, rescheduling and confirming attendance happen on their own, in the conversation, with the calendar always up to date.' },
+        { face: 'Domain', texto: 'Records and calendar come in from your spreadsheet; personal data is detected and protected.' },
+        { face: 'Trust', texto: 'Every interaction is recorded — who asked, what was done, when. Conclusion with the proof.' },
+      ],
+    },
+    humano:
+      'Complaint, urgency, delicate case: the app notices and hands the conversation to a person on your team — with the full context on screen, without the customer repeating the story.',
+    faq: [
+      {
+        q: 'Is this a chatbot?',
+        a: 'Not a chatbot that just replies. It is a self-operating app: it understands the request and resolves it — books, reschedules, confirms — and hands off to a person when the case demands. The conversation is the means; the resolved process is the end.',
+      },
+      {
+        q: 'Does my customer need to install an app or create a login?',
+        a: 'No. They resolve everything in the same WhatsApp conversation as always — booking, rescheduling, confirming — without installing anything.',
+      },
+      {
+        q: 'Does it work with the WhatsApp Business I already use?',
+        a: 'Yes — the app connects to your channel and the customer keeps talking to the number they already know.',
+      },
+      {
+        q: 'What if the customer asks for something out of the ordinary?',
+        a: 'The app doesn’t improvise: cases outside the process escalate to your team, with the full conversation history. In the sensitive cases, a person decides.',
+      },
+      {
+        q: 'Is my customers’ data safe?',
+        a: 'Your data, yours only: real isolation per company, sensitive data protected and an audit trail of every action.',
+      },
+    ],
+    atualizado: 'July 2026',
+  },
+];
+
+export function getCasoEn(slug: string): CasoDeUsoEn | undefined {
+  return CASOS_EN.find((c) => c.slug === slug);
+}
+
+// Mapa pt→en para o hreflang das páginas pt de caso.
+export const CASO_EN_SLUG_BY_PT: Record<string, string> = Object.fromEntries(
+  CASOS_EN.map((c) => [c.ptSlug, c.slug]),
+);


### PR DESCRIPTION
## O que muda

Última onda do multi-idioma (ADR-0006). Com este PR, **toda página pt tem par EN** — a única superfície só-pt que resta é a demo interativa (decisão de escopo à parte: 1 cenário vs. todos).

- **`/en/why`** — a carta do fundador, tradução fiel em 3 atos. ⚠️ Texto assinado: recomendo você reescrever no seu inglês antes ou logo após o merge.
- **`/en/use-cases`** + 3 casos com **slugs localizados** para a busca EN (`lead-management`, `collections-and-accounts-receivable`, `whatsapp-support`) — dados em `casos-en.ts` (mesmos ucIds/cenários do pt), formato GEO completo (FAQPage JSON-LD, "The request, in plain words"), deep-links para a demo pt com moldura.
- **`/en/terms`** e **`/en/privacy`** — traduções de cortesia com a nota "a versão em português prevalece"; base legal LGPD mantida.
- hreflang em todos os pares; sitemap **32 rotas**; footer/nav EN completos.

## Validação
- `tsc`, build (37 rotas no total), lint ✅; as 7 rotas novas verificadas ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YHBvrCZKmoPhGav9FesF6g