### PR TITLE
Seletor de idioma com ícone no nav (PT ⇄ EN)

### DIFF
--- a/src/app/acelere/page.tsx
+++ b/src/app/acelere/page.tsx
@@ -115,7 +115,7 @@ export default function Acelere() {
   return (
     <div className="page-ent">
       {/* NAV */}
-      <SiteHeader cta={{ label: CTA.demo, href: '/demo' }} />
+      <SiteHeader cta={{ label: CTA.demo, href: '/demo' }} enHref="/en/accelerate" />
 
       {/* HERO — dor primeiro */}
       <header className="hero">

--- a/src/app/app-operante/page.tsx
+++ b/src/app/app-operante/page.tsx
@@ -79,7 +79,7 @@ export default function AppOperante() {
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(TERM_JSONLD) }}
       />
-      <SiteHeader cta={{ label: CTA.demo, href: '/demo' }} />
+      <SiteHeader cta={{ label: CTA.demo, href: '/demo' }} enHref="/en/self-operating-app" />
 
       {/* HERO — definição na primeira frase (GEO) */}
       <header className="hero">

--- a/src/app/casos-de-uso/[slug]/page.tsx
+++ b/src/app/casos-de-uso/[slug]/page.tsx
@@ -61,7 +61,14 @@ export default async function CasoDeUsoPage({
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLd) }}
       />
-      <SiteHeader cta={{ label: CTA.demo, href: `/demo?cenario=${caso.cenario}` }} />
+      <SiteHeader
+        cta={{ label: CTA.demo, href: `/demo?cenario=${caso.cenario}` }}
+        enHref={
+          CASO_EN_SLUG_BY_PT[caso.slug]
+            ? `/en/use-cases/${CASO_EN_SLUG_BY_PT[caso.slug]}`
+            : '/en/use-cases'
+        }
+      />
 
       <header className="hero">
         <div className="wrap">

--- a/src/app/casos-de-uso/page.tsx
+++ b/src/app/casos-de-uso/page.tsx
@@ -22,7 +22,7 @@ export const metadata: Metadata = {
 export default function CasosDeUso() {
   return (
     <div className="page-ent">
-      <SiteHeader cta={{ label: CTA.demo, href: '/demo' }} />
+      <SiteHeader cta={{ label: CTA.demo, href: '/demo' }} enHref="/en/use-cases" />
 
       <header className="hero">
         <div className="wrap">

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -86,9 +86,18 @@ nav .wrap { display: flex; align-items: center; justify-content: space-between; 
 .navlinks a:hover { color: #fff; }
 .nav-cta { padding: 10px 20px; font-size: 15px; white-space: nowrap; }
 .navright { display: flex; align-items: center; }
+/* seletor de idioma: globo + rótulo do idioma alvo, discreto por design */
+.langsw {
+  display: inline-flex; align-items: center; gap: 5px;
+  color: #9aa1ab; font-size: 12.5px; font-weight: 600; letter-spacing: .04em;
+  border: 1px solid rgba(255,255,255,.14); border-radius: 999px;
+  padding: 5px 10px; margin-right: 12px; transition: .15s;
+}
+.langsw svg { width: 14px; height: 14px; }
+.langsw:hover { color: #fff; border-color: rgba(255,255,255,.35); }
 @media (max-width: 1300px) { .navlinks { gap: 14px; } .navlinks a { font-size: 13.5px; } .nav-cta { padding: 9px 14px; font-size: 14px; } }
 @media (max-width: 1040px) { .navlinks { display: none; } }
-@media (max-width: 480px) { .brand .brandlogo { height: 20px; } .nav-cta { display: none; } }
+@media (max-width: 480px) { .brand .brandlogo { height: 20px; } .nav-cta { display: none; } .langsw { margin-right: 8px; } }
 
 /* ---------- hero (base) ---------- */
 .hero { position: relative; background: radial-gradient(1100px 520px at 80% -10%, rgba(43,102,221,.4), transparent 60%), var(--ink); color: #fff; overflow: hidden; }

--- a/src/app/o-que-tem/page.tsx
+++ b/src/app/o-que-tem/page.tsx
@@ -91,7 +91,7 @@ const CARDS = FACES.map((f) => ({ ...f, ...FACE_DETAILS[f.key] }));
 export default function OQueTem() {
   return (
     <div className="page-feats">
-      <SiteHeader cta={{ label: CTA.demo, href: '/demo' }} />
+      <SiteHeader cta={{ label: CTA.demo, href: '/demo' }} enHref="/en/what-it-does" />
 
       {/* HERO */}
       <header className="hero">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -134,7 +134,7 @@ export default function Home() {
       <style>{HOME_CSS}</style>
 
       {/* NAV — CTA primário leva à demonstração (a conversão é viver a demo) */}
-      <SiteHeader cta={{ label: CTA.demo, href: '/demo' }} />
+      <SiteHeader cta={{ label: CTA.demo, href: '/demo' }} enHref="/en" />
 
       {/* HERO */}
       <header className="hero">

--- a/src/app/plataforma/page.tsx
+++ b/src/app/plataforma/page.tsx
@@ -50,7 +50,7 @@ export default function Plataforma() {
   return (
     <div className="page-tech">
       {/* NAV */}
-      <SiteHeader cta={{ label: CTA.demo, href: '/demo' }} />
+      <SiteHeader cta={{ label: CTA.demo, href: '/demo' }} enHref="/en/platform" />
 
       {/* HERO — prova de execução */}
       <header className="hero">

--- a/src/app/por-que/page.tsx
+++ b/src/app/por-que/page.tsx
@@ -20,7 +20,7 @@ export default function PorQue() {
     <div className="page-porque">
       <style>{PQ_CSS}</style>
 
-      <SiteHeader cta={{ label: CTA.demo, href: '/demo' }} />
+      <SiteHeader cta={{ label: CTA.demo, href: '/demo' }} enHref="/en/why" />
 
       {/* ABERTURA */}
       <header className="hero">

--- a/src/app/precos/page.tsx
+++ b/src/app/precos/page.tsx
@@ -18,7 +18,7 @@ export const metadata: Metadata = {
 export default function Precos() {
   return (
     <div className="page-pricing">
-      <SiteHeader cta={{ label: CTA.demo, href: '/demo' }} />
+      <SiteHeader cta={{ label: CTA.demo, href: '/demo' }} enHref="/en/pricing" />
 
       {/* HERO */}
       <header className="hero">

--- a/src/app/seguranca/page.tsx
+++ b/src/app/seguranca/page.tsx
@@ -105,7 +105,7 @@ const GOVERNANCE = [
 export default function Seguranca() {
   return (
     <div className="page-feats">
-      <SiteHeader cta={{ label: CTA.demo, href: '/demo' }} />
+      <SiteHeader cta={{ label: CTA.demo, href: '/demo' }} enHref="/en/security" />
 
       {/* HERO — governança como recurso, não compliance */}
       <header className="hero">

--- a/src/components/LangSwitch.tsx
+++ b/src/components/LangSwitch.tsx
@@ -1,0 +1,31 @@
+import Link from 'next/link';
+
+// Seletor de idioma do nav — globo + rótulo do idioma ALVO (clicou, trocou).
+// `href` é o par exato da página no outro idioma (mesmo mapa do hreflang);
+// cada página passa o seu. Discreto por design: cabe entre os links e o CTA.
+export default function LangSwitch({
+  href,
+  target,
+}: {
+  href: string;
+  target: 'EN' | 'PT';
+}) {
+  const lang = target === 'EN' ? 'en' : 'pt-BR';
+  const title = target === 'EN' ? 'Read in English' : 'Ler em português';
+  return (
+    <Link href={href} className="langsw" lang={lang} title={title} aria-label={title}>
+      <svg
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.7"
+        strokeLinecap="round"
+        aria-hidden="true"
+      >
+        <circle cx="12" cy="12" r="9" />
+        <path d="M3 12h18M12 3a14.5 14.5 0 0 1 0 18M12 3a14.5 14.5 0 0 0 0 18" />
+      </svg>
+      {target}
+    </Link>
+  );
+}

--- a/src/components/SiteHeader.tsx
+++ b/src/components/SiteHeader.tsx
@@ -1,6 +1,7 @@
 import Image from 'next/image';
 import Link from 'next/link';
 import MobileNav from '@/components/MobileNav';
+import LangSwitch from '@/components/LangSwitch';
 import { NAV_LINKS } from '@/lib/nav';
 
 type Cta = { label: string; href: string };
@@ -11,7 +12,9 @@ type Cta = { label: string; href: string };
 // (decisão do fundador 2026-07-02) — betas recebem a URL do time.
 // ≤1040px: links colapsam no MobileNav (hambúrguer); ≤480px o CTA
 // também vive só dentro do menu.
-export default function SiteHeader({ cta }: { cta: Cta }) {
+// `enHref`: par exato da página em inglês (mesmo mapa do hreflang);
+// default /en cobre páginas sem par específico.
+export default function SiteHeader({ cta, enHref = '/en' }: { cta: Cta; enHref?: string }) {
   return (
     <nav>
       <div className="wrap">
@@ -33,10 +36,11 @@ export default function SiteHeader({ cta }: { cta: Cta }) {
           ))}
         </div>
         <div className="navright">
+          <LangSwitch href={enHref} target="EN" />
           <a className="btn btn-primary nav-cta" href={cta.href}>
             {cta.label}
           </a>
-          <MobileNav cta={cta} />
+          <MobileNav cta={cta} links={[...NAV_LINKS, { href: enHref, label: 'English' }]} />
         </div>
       </div>
     </nav>

--- a/src/components/SiteHeaderEn.tsx
+++ b/src/components/SiteHeaderEn.tsx
@@ -1,6 +1,7 @@
 import Image from 'next/image';
 import Link from 'next/link';
 import MobileNav from '@/components/MobileNav';
+import LangSwitch from '@/components/LangSwitch';
 import { CTA_EN } from '@/lib/messages-en';
 
 // Chrome EN — mesmo padrão visual do SiteHeader pt (nav escura sticky do
@@ -37,11 +38,9 @@ export default function SiteHeaderEn({ ptHref }: { ptHref: string }) {
               {l.label}
             </Link>
           ))}
-          <Link href={ptHref} lang="pt-BR">
-            Português
-          </Link>
         </div>
         <div className="navright">
+          <LangSwitch href={ptHref} target="PT" />
           <Link className="btn btn-primary nav-cta" href="/demo">
             {CTA_EN.demo}
           </Link>


### PR DESCRIPTION
Achado da validação do fundador: a troca de idioma no pt só existia no footer (assimétrica e invisível).

- **LangSwitch**: pill discreta 🌐 + rótulo do idioma alvo, no navright das duas árvores, antes do CTA.
- Sempre aponta para o **par exato** da página (mesmo mapa do hreflang) — /precos → /en/pricing, caso pt → caso en via `CASO_EN_SLUG_BY_PT`.
- Hambúrguer pt ganha o item "English"; mobile ≤480px mantém a pill (o CTA é que some).
- Verificado visualmente (screenshot) e no HTML das duas direções.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YHBvrCZKmoPhGav9FesF6g