### PR TITLE
Pré-lançamento: beta privado + lista de lançamento + nova assinatura

### DIFF
--- a/docs/message-house-cliente-final.md
+++ b/docs/message-house-cliente-final.md
@@ -11,7 +11,7 @@ Este documento governa toda a copy do site. Strings compartilhadas entre página
 
 ## 1. Hierarquia de mensagem
 
-1. **Assinatura (h1 canônico, todo lugar):** *Delegue a tarefa. Receba a conclusão com a prova.*
+1. **Assinatura (h1 canônico, todo lugar):** *App que trabalha para o seu negócio — não o contrário.* (Emenda 2026-07-07, decisão do fundador — substitui "Delegue a tarefa. Receba a conclusão com a prova."; "conclusão com a prova" segue no léxico como argumento de corpo, não mais como assinatura. EN: *An app that works for your business — not the other way around.*)
 2. **Promessa ao cliente final (BCM slide 8):** *Um app que resolve o seu problema e se opera sozinho — integrado ao que você já tem, governado, em semanas (não num projeto de meses).*
 3. **Categoria:** **app operante** / negócio de software vivo. A 3ª categoria, entre o software rígido e a consultoria humana. Por 30 anos a empresa se adaptou ao software; a Fluxomind inverte: **o software se molda à empresa — e opera o processo.**
 4. **Eixo de diferenciação (anti-Lovable, linguagem de cliente):** *Construir ficou fácil — qualquer IA te entrega um protótipo. Operar é o que falta.* A Fluxomind entrega o processo **rodando**: o app se constrói a partir do seu problema, opera o dia a dia e chama um humano nos casos sensíveis.
@@ -67,6 +67,8 @@ Três capítulos — nunca apresentar visão como fato:
 
 A visão de especialistas aparece como **para onde isso vai**, uma banda por página no máximo, sempre em linguagem de visão ("estamos construindo", "o próximo capítulo").
 
+**Estado de acesso (emenda 2026-07-07, decisão do fundador):** a plataforma existe e opera, mas **não está lançada ao público**. O estado público canônico é **"beta privado · lançamento aberto em breve"** — nunca "em breve" solto (sinaliza vaporware e subvende a demo), nunca sugerir acesso self-service aberto. A captura primária passa a ser comunicada como **lista de lançamento**: quem entra é avisado no lançamento e os primeiros entram já no beta acompanhado, com o time montando o primeiro app junto (a limitação vira vantagem legítima, não "deixe seu e-mail" passivo).
+
 ## 6. CTAs (arquitetura de conversão)
 
 A conversão principal do site é **viver a demonstração** — o encantamento vem antes do formulário.
@@ -74,7 +76,7 @@ A conversão principal do site é **viver a demonstração** — o encantamento 
 | Papel | Rótulo canônico | Destino |
 |---|---|---|
 | Primário (nav + hero) | **Crie um app conversando** (= h1 da /demo; verbo de fazer, não de assistir) | `/demo` (a jornada interativa) — exceção: em `/demo` o nav CTA é `CTA.beta → #beta`. A demo curta da home segue em `/#demo`, acessada por rótulo próprio ("Prévia em 1 minuto ↓"). Sem link "Experimente" no nav — o CTA é a entrada única |
-| Pós-demonstração / decisão | **Quero isso no meu negócio** | Form da lista do beta (`BetaForm` em `/#comecar`); todo CTA de beta ancora lá. `PLATFORM_BETA` (mailto) é só fallback de erro do form |
+| Pós-demonstração / decisão | **Quero isso no meu negócio** | Form da **lista de lançamento** (`BetaForm` em `/#comecar`); todo CTA de beta ancora lá. `PLATFORM_BETA` (mailto) é só fallback de erro do form |
 | Humano / escala | **Falar com o time** | `PLATFORM_CONTACT` |
 | Quem já é beta | **Entrar** | `PLATFORM_LOGIN` — **omitido do site enquanto a plataforma não lança** (decisão 2026-07-02); betas recebem a URL do time |
 
@@ -82,9 +84,9 @@ A conversão principal do site é **viver a demonstração** — o encantamento 
 
 ## 7. Léxico
 
-**Usar:** app operante · negócio de software vivo · opera o dia a dia · conclusão com a prova · governado · se molda à empresa · escala para um humano (handoff) · em semanas, não meses · fica mais inteligente quanto mais você usa · uma fatura em reais (managed LLM).
+**Usar:** app operante · negócio de software vivo · opera o dia a dia · conclusão com a prova · governado · se molda à empresa · escala para um humano (handoff) · em semanas, não meses · fica mais inteligente quanto mais você usa · uma fatura em reais (managed LLM) · beta privado · lista de lançamento · lançamento aberto em breve.
 
-**Vetado:** "código morto" (vetado pelo fundador) · "6 dimensões" fora de /plataforma · "substrato vivo" · "waitlist" (dizer "lista do beta") · "data room" em botão · superlativo sem fonte · qualquer claim de catálogo/marketplace/avatar como existente · promessa de resultado financeiro específico · **nomear concorrente na copy do site** (Lovable/v0/Bolt/Palantir etc. — "anti-Lovable" é linguagem interna; no site, comparar com a categoria: "builder de código", "no-code genérico"). SoRs a que a plataforma se integra (SAP/Salesforce/TOTVS) podem ser nomeados — são integração, não comparação.
+**Vetado:** "código morto" (vetado pelo fundador) · "6 dimensões" fora de /plataforma · "substrato vivo" · "waitlist" (dizer "lista de lançamento"; antes de 2026-07-07 era "lista do beta") · "em breve" sem "beta privado" junto (vaporware) · "data room" em botão · superlativo sem fonte · qualquer claim de catálogo/marketplace/avatar como existente · promessa de resultado financeiro específico · **nomear concorrente na copy do site** (Lovable/v0/Bolt/Palantir etc. — "anti-Lovable" é linguagem interna; no site, comparar com a categoria: "builder de código", "no-code genérico"). SoRs a que a plataforma se integra (SAP/Salesforce/TOTVS) podem ser nomeados — são integração, não comparação.
 
 **Números com fonte (usáveis):** 39 engines em 10 camadas (fato — plataforma) · 79% das empresas adotaram agentes, só 11% em produção (o gap que a categoria "operar" fecha) · 45% do código gerado por IA falha em segurança (Veracode) — usar no máximo 1× no site, em /acelere ou home.
 

--- a/docs/message-house-en.md
+++ b/docs/message-house-en.md
@@ -16,7 +16,7 @@
 
 ## 1. Redações canônicas (espelho do message house pt)
 
-- **Assinatura:** *Delegate the task. Get the conclusion — with the proof.*
+- **Assinatura:** *The app that works for your business — not the other way around.* (emenda 2026-07-07, espelho da lei pt; substitui "Delegate the task. Get the conclusion — with the proof."; "The" em vez de "An" — artigo definido é o padrão assertivo de slogan em inglês)
 - **Promessa:** *An app that solves your problem and runs itself — integrated with what you already use, governed, live in weeks (not a months-long project).*
 - **Propósito:** *For 30 years, companies adapted to their software. We exist to invert that: software that molds itself to your business — and works for it.*
 - **Negação tripla:**
@@ -43,10 +43,12 @@ Trust rules: **Framing** (solves the right problem) · **Coherence** (makes sens
 
 Already real: the platform — 39 engines that materialize and operate real apps, multi-tenant, governed. Next chapter: dogfooding — Fluxomind running its own sales operation inside the product. The vision: a catalog of self-operating apps created by experts — declared as vision, never as fact.
 
+**Estado de acesso (emenda 2026-07-07, espelho da lei pt):** a plataforma **não está lançada** — estado público canônico: **"private beta · open launch coming soon"**; nunca "coming soon" solto. A captura é a **launch list** (espelho de "lista de lançamento"): quem entra é avisado no lançamento e os primeiros entram já no beta acompanhado.
+
 ## 4. Léxico EN
 
-**Usar:** self-operating app · runs the day-to-day · conclusion with the proof · governed · molds itself to the business · hands off to a human · live in weeks, not months.
-**Vetado:** mesmos vetos da lei pt (concorrentes nomeados, superlativo sem fonte, promessa financeira, catálogo como fato, "waitlist") + **não traduzir "app operante" de outra forma** — um termo só, sempre.
+**Usar:** self-operating app · runs the day-to-day · conclusion with the proof · governed · molds itself to the business · hands off to a human · live in weeks, not months · private beta · launch list · open launch coming soon.
+**Vetado:** mesmos vetos da lei pt (concorrentes nomeados, superlativo sem fonte, promessa financeira, catálogo como fato, "waitlist" — dizer "launch list") + **não traduzir "app operante" de outra forma** — um termo só, sempre.
 
 ## 5. Regras desta fase
 

--- a/src/app/acelere/page.tsx
+++ b/src/app/acelere/page.tsx
@@ -300,8 +300,8 @@ export default function Acelere() {
             </div>
           </div>
           <div className="honest">
-            <b>Transparência.</b> {PHASE.exists.title}: {PHASE.exists.desc} Estamos em beta — a
-            adoção acontece acompanhada de perto pelo nosso time; SLA formal e certificações estão
+            <b>Transparência.</b> {PHASE.exists.title}: {PHASE.exists.desc} No beta, a adoção
+            acontece acompanhada de perto pelo nosso time; SLA formal e certificações estão
             no roadmap. {PHASE.vision.title}: {PHASE.vision.desc}
           </div>
         </div>

--- a/src/app/api/beta/route.ts
+++ b/src/app/api/beta/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from 'next/server';
 import { clientIp, rateLimited } from '@/lib/ratelimit';
 import { appendLead } from '@/lib/leadstore';
 
-// Captura de leads do form da lista do beta (src/components/BetaForm.tsx).
+// Captura de leads do form da lista de lançamento (src/components/BetaForm.tsx).
 // O lead é SEMPRE logado (backup nos logs do host — atenção à retenção curta
 // na Vercel; ver docs/leads-analytics.md § Deploy) e repassado a
 // LEAD_WEBHOOK_URL quando configurada (Sheets via Apps Script, CRM, Slack…).

--- a/src/app/app-operante/page.tsx
+++ b/src/app/app-operante/page.tsx
@@ -46,7 +46,7 @@ const FAQ = [
   },
   {
     q: 'Isso já existe ou é visão?',
-    a: 'A plataforma já existe — 39 engines que materializam e operam apps de verdade, multi-tenant, governada. Estamos em beta: a adoção acontece acompanhada de perto pelo nosso time, em semanas, não num projeto de meses.',
+    a: 'A plataforma já existe — 39 engines que materializam e operam apps de verdade, multi-tenant, governada. Estamos em beta privado, com o lançamento aberto em breve: a adoção acontece acompanhada de perto pelo nosso time, em semanas, não num projeto de meses.',
   },
 ];
 

--- a/src/app/casos-de-uso/[slug]/page.tsx
+++ b/src/app/casos-de-uso/[slug]/page.tsx
@@ -230,7 +230,7 @@ export default async function CasoDeUsoPage({
           <div className="honest">
             <b>Transparência.</b> A demonstração deste caso usa dados de exemplo — o app real
             nasce dentro da plataforma, com os seus dados. {PHASE.exists.title}:{' '}
-            {PHASE.exists.desc} Estamos em beta: a adoção acontece acompanhada de perto pelo
+            {PHASE.exists.desc} No beta, a adoção acontece acompanhada de perto pelo
             nosso time, em semanas — não num projeto de meses.
           </div>
           <p style={{ textAlign: 'center', marginTop: 14, fontSize: 13.5, color: 'var(--slate)' }}>

--- a/src/app/demo/page.tsx
+++ b/src/app/demo/page.tsx
@@ -39,8 +39,10 @@ export default function DemoPage() {
         <div className="wrap">
           <h2>Agora com os seus dados de verdade</h2>
           <p className="lead">
-            Conte qual processo você quer delegar — o time monta o primeiro app operante com
-            você, sem cartão e sem compromisso.
+            A plataforma está em beta privado — o lançamento aberto vem em breve. Entre na
+            lista de lançamento contando qual processo você quer delegar: os primeiros da
+            lista entram já no beta, com o time montando o primeiro app operante com você,
+            sem cartão e sem compromisso.
           </p>
           <BetaForm />
         </div>

--- a/src/app/en/accelerate/page.tsx
+++ b/src/app/en/accelerate/page.tsx
@@ -268,7 +268,7 @@ export default function AccelerateEn() {
             </div>
           </div>
           <div className="honest">
-            <b>Transparency.</b> {PHASE_EN.exists} We are in beta — we guide adoption
+            <b>Transparency.</b> {PHASE_EN.exists} In the beta, we guide adoption
             closely; formal SLAs and certifications are on the roadmap.{' '}
             {PHASE_EN.vision}
           </div>

--- a/src/app/en/demo/page.tsx
+++ b/src/app/en/demo/page.tsx
@@ -38,7 +38,8 @@ export default function DemoPageEn() {
         <div className="wrap">
           <h2>Now with your real data</h2>
           <p className="lead">
-            Tell us which process you want to delegate — the team builds your first
+            The platform is in private beta — open launch coming soon. Tell us which process
+            you want to delegate: early access starts with the team building your first
             self-operating app with you, no card and no commitment.
           </p>
           <div className="offerbtns">

--- a/src/app/en/page.tsx
+++ b/src/app/en/page.tsx
@@ -27,9 +27,9 @@ export const metadata: Metadata = {
 // Landing EN — escopo credibilidade (message-house-en.md, PROPOSTA):
 // condensa a home pt; a demo permanece em português com moldura honesta.
 // Assinatura fatiada como na home pt (head branco, tail azul).
-const SIG_BREAK = SIGNATURE_EN.indexOf('. ') + 1;
-const SIG_HEAD = SIGNATURE_EN.slice(0, SIG_BREAK);
-const SIG_TAIL = SIGNATURE_EN.slice(SIG_BREAK + 1);
+const SIG_BREAK = SIGNATURE_EN.indexOf(' — ');
+const SIG_HEAD = SIGNATURE_EN.slice(0, SIG_BREAK); // "The app that works for your business"
+const SIG_TAIL = SIGNATURE_EN.slice(SIG_BREAK + 1); // "— not the other way around."
 
 export default function HomeEn() {
   return (
@@ -41,7 +41,7 @@ export default function HomeEn() {
       <header className="hero">
         <div className="wrap" style={{ textAlign: 'center', paddingBottom: 48 }}>
           <span className="pill">
-            <span className="lz" /> Platform in beta · self-operating apps
+            <span className="lz" /> Private beta · open launch coming soon
           </span>
           <h1 style={{ maxWidth: '24ch', margin: '0 auto' }}>
             {SIG_HEAD} <span className="g">{SIG_TAIL}</span>
@@ -143,8 +143,8 @@ export default function HomeEn() {
             <h2 style={{ maxWidth: '30ch', margin: '0 auto' }}>{PURPOSE_LINE_EN}</h2>
           </div>
           <div className="honest" style={{ marginTop: 28 }}>
-            <b>Transparency.</b> {PHASE_EN.exists} {PHASE_EN.next} {PHASE_EN.vision} We are in
-            beta: adoption happens closely guided by our team — live in weeks, not a
+            <b>Transparency.</b> {PHASE_EN.exists} {PHASE_EN.next} {PHASE_EN.vision} In the
+            beta, adoption happens closely guided by our team — live in weeks, not a
             months-long project.
           </div>
         </div>

--- a/src/app/en/pricing/page.tsx
+++ b/src/app/en/pricing/page.tsx
@@ -8,7 +8,7 @@ import { PLATFORM_CONTACT_EN } from '@/lib/platform';
 export const metadata: Metadata = {
   title: 'Pricing',
   description:
-    'During the beta, you get hands-on support and no card is required — you join through the beta list. Afterwards, subscription + usage with frontier AI models included: one invoice, no AI provider accounts or keys to manage.',
+    'The platform is in private beta — hands-on support, no card required; you join through the launch list. Afterwards, subscription + usage with frontier AI models included: one invoice, no AI provider accounts or keys to manage.',
   alternates: {
     canonical: '/en/pricing',
     languages: { 'pt-BR': '/precos', en: '/en/pricing' },
@@ -33,8 +33,9 @@ export default function PricingEn() {
               In beta: no card. <span className="g">After: subscription + usage.</span>
             </h1>
             <p className="hsub" style={{ margin: '18px auto 0', maxWidth: '56ch' }}>
-              During the beta, you get hands-on support — our team works alongside you, with no card and no
-              charges. Afterwards, the design is simple: a subscription plus usage, with frontier
+              The platform is in private beta — open launch coming soon. In the beta, you get
+              hands-on support: our team works alongside you, with no card and no charges.
+              Afterwards, the design is simple: a subscription plus usage, with frontier
               AI models already included in a single invoice.
             </p>
           </div>
@@ -45,7 +46,7 @@ export default function PricingEn() {
         <div className="wrap">
           <div className="plans">
             <div className="plan">
-              <div className="ptag">Today · beta</div>
+              <div className="ptag">Today · private beta</div>
               <h3>Guided beta</h3>
               <div className="price">
                 <b>No card</b>
@@ -56,7 +57,7 @@ export default function PricingEn() {
                 self-operating app.
               </p>
               <ul>
-                <li><span className="ck">✓</span> Access through the beta list, guided by the team</li>
+                <li><span className="ck">✓</span> Access through the launch list, guided by the team</li>
                 <li><span className="ck">✓</span> No card and no charges for the duration of the beta</li>
                 <li><span className="ck">✓</span> A real self-operating app, on your process</li>
                 <li><span className="ck">✓</span> Your data isolated from day one</li>
@@ -127,8 +128,8 @@ export default function PricingEn() {
             <div className="qa">
               <h4>Do I need a card to start?</h4>
               <p>
-                No. During the beta there are no charges and no card. You request access and get
-                onboarded with the team — they build your first self-operating app with you.
+                No. During the beta there are no charges and no card. You join the launch list
+                and get onboarded with the team — they build your first self-operating app with you.
               </p>
             </div>
             <div className="qa">

--- a/src/app/en/privacy/page.tsx
+++ b/src/app/en/privacy/page.tsx
@@ -67,9 +67,9 @@ export default function PrivacyEn() {
             </p>
             <ul className="list-disc pl-6 text-gray-600 space-y-2 mb-4">
               <li>
-                <strong>Data you send us:</strong> when filling in the beta interest form, we
-                collect name, e-mail, company and the description of the process you want to
-                automate.
+                <strong>Data you send us:</strong> when filling in the launch-list (beta
+                program) form, we collect name, e-mail, company and the description of the
+                process you want to automate.
               </li>
               <li>
                 <strong>Browsing data (anonymous):</strong> we record usage events on the Site
@@ -90,8 +90,9 @@ export default function PrivacyEn() {
             <h2 className="text-2xl font-semibold text-gray-900 mb-4">3. Why we use it and on which legal basis</h2>
             <ul className="list-disc pl-6 text-gray-600 space-y-2 mb-4">
               <li>
-                <strong>Responding to your interest in the beta:</strong> we use the form data to
-                contact you about the beta program and evaluate your use case. Legal basis:
+                <strong>Responding to your interest in the beta and the launch:</strong> we use
+                the form data to notify you about the launch, contact you about the beta program
+                and evaluate your use case. Legal basis:
                 consent (LGPD art. 7, I) and preliminary procedures related to a contract (LGPD
                 art. 7, V).
               </li>

--- a/src/app/en/self-operating-app/page.tsx
+++ b/src/app/en/self-operating-app/page.tsx
@@ -47,7 +47,7 @@ const FAQ_EN = [
   },
   {
     q: 'Is this real today, or a vision?',
-    a: 'The platform is real — 39 engines that materialize and operate real apps, multi-tenant, governed. We are in beta: we guide adoption closely — live in weeks, not a months-long project.',
+    a: 'The platform is real — 39 engines that materialize and operate real apps, multi-tenant, governed. We are in private beta, with the open launch coming soon: we guide adoption closely — live in weeks, not a months-long project.',
   },
 ];
 

--- a/src/app/en/use-cases/[slug]/page.tsx
+++ b/src/app/en/use-cases/[slug]/page.tsx
@@ -210,8 +210,8 @@ export default async function UseCasePageEn({
         <div className="wrap">
           <div className="honest">
             <b>Transparency.</b> The demo of this case uses sample data —
-            the real app is born inside the platform, with your data. {PHASE_EN.exists} We are
-            in beta: we guide adoption closely, in weeks — not a
+            the real app is born inside the platform, with your data. {PHASE_EN.exists} In the
+            beta, we guide adoption closely, in weeks — not a
             months-long project.
           </div>
           <p style={{ textAlign: 'center', marginTop: 14, fontSize: 13.5, color: 'var(--slate)' }}>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -12,7 +12,7 @@ const inter = Inter({
 export const metadata: Metadata = {
   metadataBase: new URL("https://www.fluxomind.com"),
   title: {
-    default: "Fluxomind — delegue a tarefa, receba a conclusão com a prova",
+    default: "Fluxomind — app que trabalha para o seu negócio, não o contrário",
     template: "%s · Fluxomind",
   },
   description:
@@ -21,7 +21,7 @@ export const metadata: Metadata = {
     type: "website",
     locale: "pt_BR",
     siteName: "Fluxomind",
-    title: "Fluxomind — delegue a tarefa, receba a conclusão com a prova",
+    title: "Fluxomind — app que trabalha para o seu negócio, não o contrário",
     description:
       "Um app que resolve o seu problema e se opera sozinho — integrado ao que você já tem, governado, em semanas.",
     images: [

--- a/src/app/o-que-tem/page.tsx
+++ b/src/app/o-que-tem/page.tsx
@@ -215,7 +215,7 @@ export default function OQueTem() {
           </div>
           <h2>Quer isso respondendo pelo seu negócio?</h2>
           <p className="lead" style={{ maxWidth: '56ch', margin: '14px auto 0' }}>
-            Entre na lista do beta e conte qual processo você quer delegar — o time monta o app com
+            Entre na lista de lançamento e conte qual processo você quer delegar — o time monta o app com
             você. Ou fale direto com a gente.
           </p>
           <div className="offerbtns">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -18,7 +18,7 @@ import {
 import { PLATFORM_CONTACT } from '@/lib/platform';
 
 export const metadata: Metadata = {
-  title: { absolute: 'Fluxomind — delegue a tarefa, receba a conclusão com a prova' },
+  title: { absolute: 'Fluxomind — app que trabalha para o seu negócio, não o contrário' },
   description:
     'Um app que resolve o seu problema e se opera sozinho — integrado ao que você já tem, governado, em semanas. Veja a demonstração: o app se constrói na sua frente e opera o dia a dia, com humano nos casos sensíveis.',
   alternates: {
@@ -28,9 +28,9 @@ export const metadata: Metadata = {
 };
 
 // Assinatura canônica (messages.ts), com destaque visual na segunda frase.
-const SIG_BREAK = SIGNATURE.indexOf('. ') + 1;
-const SIG_HEAD = SIGNATURE.slice(0, SIG_BREAK); // "Delegue a tarefa."
-const SIG_TAIL = SIGNATURE.slice(SIG_BREAK).trim(); // "Receba a conclusão com a prova."
+const SIG_BREAK = SIGNATURE.indexOf(' — ');
+const SIG_HEAD = SIGNATURE.slice(0, SIG_BREAK); // "App que trabalha para o seu negócio"
+const SIG_TAIL = SIGNATURE.slice(SIG_BREAK + 1); // "— não o contrário."
 
 const ICON_PROPS = {
   viewBox: '0 0 24 24',
@@ -114,7 +114,7 @@ const FAQ_JSONLD = {
       name: 'Em quanto tempo estou rodando?',
       acceptedAnswer: {
         '@type': 'Answer',
-        text: 'Em semanas, não num projeto de meses. No beta, o time acompanha de perto: o primeiro caso a gente monta com você.',
+        text: 'Em semanas, não num projeto de meses. No beta privado, o time acompanha de perto: o primeiro caso a gente monta com você.',
       },
     },
     {
@@ -122,7 +122,7 @@ const FAQ_JSONLD = {
       name: 'Quanto custa?',
       acceptedAnswer: {
         '@type': 'Answer',
-        text: 'Durante o beta, ninguém pede cartão: o acesso é acompanhado e sem custo para começar. Os planos estão na página de Preços.',
+        text: 'A plataforma está em beta privado — o lançamento aberto vem em breve. Durante o beta, ninguém pede cartão: o acesso é acompanhado e sem custo para começar. Os planos estão na página de Preços.',
       },
     },
   ],
@@ -140,7 +140,7 @@ export default function Home() {
       <header className="hero">
         <div className="wrap" style={{ textAlign: 'center', paddingBottom: 48 }}>
           <span className="pill">
-            <span className="lz" /> Plataforma em beta · a demonstração está logo abaixo
+            <span className="lz" /> Beta privado · lançamento aberto em breve
           </span>
           <h1 style={{ maxWidth: '24ch', margin: '0 auto' }}>
             {SIG_HEAD} <span className="g">{SIG_TAIL}</span>
@@ -508,15 +508,16 @@ export default function Home() {
             <div className="qa">
               <h4>Em quanto tempo estou rodando?</h4>
               <p>
-                Em semanas, não num projeto de meses. No beta, o time acompanha de perto: o
-                primeiro caso a gente monta com você.
+                Em semanas, não num projeto de meses. No beta privado, o time acompanha de
+                perto: o primeiro caso a gente monta com você.
               </p>
             </div>
             <div className="qa">
               <h4>Quanto custa?</h4>
               <p>
-                Durante o beta, ninguém pede cartão: o acesso é acompanhado e sem custo para
-                começar. Os planos estão em <Link href="/precos" style={{ color: 'var(--blue)', fontWeight: 600 }}>Preços</Link>.
+                A plataforma está em beta privado — o lançamento aberto vem em breve. Durante
+                o beta, ninguém pede cartão: o acesso é acompanhado e sem custo para começar.
+                Os planos estão em <Link href="/precos" style={{ color: 'var(--blue)', fontWeight: 600 }}>Preços</Link>.
               </p>
             </div>
           </div>
@@ -531,8 +532,10 @@ export default function Home() {
           </div>
           <h2>Delegue a primeira tarefa</h2>
           <p className="lead">
-            Conte qual problema você quer tirar das costas. No beta, montamos o primeiro app
-            operante com você — e você recebe a conclusão com a prova.
+            A plataforma está em beta privado — o lançamento aberto vem em breve. Entre na
+            lista de lançamento contando qual problema você quer tirar das costas: você é
+            avisado quando abrir, e os primeiros da lista entram já no beta, com o time
+            montando o primeiro app operante com você.
           </p>
           <BetaForm />
           <div className="offerbtns" style={{ marginTop: 18 }}>

--- a/src/app/precos/page.tsx
+++ b/src/app/precos/page.tsx
@@ -8,7 +8,7 @@ import { PLATFORM_CONTACT } from '@/lib/platform';
 export const metadata: Metadata = {
   title: 'Preços',
   description:
-    'Durante o beta, o acesso é acompanhado e sem cartão — você entra pela lista do beta. Depois, assinatura + uso com os modelos de fronteira inclusos: uma fatura, em reais, sem gerir contas e chaves de IA.',
+    'A plataforma está em beta privado — o acesso é acompanhado e sem cartão; você entra pela lista de lançamento. Depois, assinatura + uso com os modelos de fronteira inclusos: uma fatura, em reais, sem gerir contas e chaves de IA.',
   alternates: {
     canonical: '/precos',
     languages: { 'pt-BR': '/precos', en: '/en/pricing' },
@@ -31,9 +31,10 @@ export default function Precos() {
               No beta, sem cartão. <span className="g">Depois, assinatura + uso.</span>
             </h1>
             <p className="hsub" style={{ margin: '18px auto 0', maxWidth: '56ch' }}>
-              Durante o beta, o acesso é acompanhado — o time entra junto, sem cartão e sem
-              cobrança. Depois, o desenho é simples: uma assinatura mais o uso, com os modelos de
-              fronteira já inclusos numa única fatura em reais.
+              A plataforma está em beta privado — o lançamento aberto vem em breve. No beta, o
+              acesso é acompanhado: o time entra junto, sem cartão e sem cobrança. Depois, o
+              desenho é simples: uma assinatura mais o uso, com os modelos de fronteira já
+              inclusos numa única fatura em reais.
             </p>
           </div>
         </div>
@@ -45,7 +46,7 @@ export default function Precos() {
           <div className="plans">
             {/* BETA */}
             <div className="plan">
-              <div className="ptag">Hoje · beta</div>
+              <div className="ptag">Hoje · beta privado</div>
               <h3>Beta acompanhado</h3>
               <div className="price">
                 <b>Sem cartão</b>
@@ -56,7 +57,7 @@ export default function Precos() {
               </p>
               <ul>
                 <li>
-                  <span className="ck">✓</span> Acesso pela lista do beta, acompanhado pelo time
+                  <span className="ck">✓</span> Acesso pela lista de lançamento, acompanhado pelo time
                 </li>
                 <li>
                   <span className="ck">✓</span> Sem cartão e sem cobrança enquanto durar o beta
@@ -155,8 +156,8 @@ export default function Precos() {
             <div className="qa">
               <h4>Preciso de cartão para começar?</h4>
               <p>
-                Não. Durante o beta não existe cobrança nem cartão. Você pede acesso pela lista do
-                beta e entra acompanhado — o time monta com você o primeiro app operante.
+                Não. Durante o beta não existe cobrança nem cartão. Você entra na lista de
+                lançamento e o acesso é acompanhado — o time monta com você o primeiro app operante.
               </p>
             </div>
             <div className="qa">
@@ -206,9 +207,10 @@ export default function Precos() {
           <div className="kick" style={{ color: 'var(--sky)' }}>
             Comece agora
           </div>
-          <h2>Entre pela lista do beta</h2>
+          <h2>Entre na lista de lançamento</h2>
           <p className="lead">
-            Sem cartão, acompanhado pelo time — do problema descrito ao app operante rodando.
+            Você é avisado quando abrir — e os primeiros da lista entram já no beta, sem cartão,
+            acompanhados pelo time: do problema descrito ao app operante rodando.
           </p>
           <div className="offerbtns">
             <Link className="btn btn-primary btn-lg" href="/#comecar" data-track="precos-beta-cta">

--- a/src/app/privacidade/page.tsx
+++ b/src/app/privacidade/page.tsx
@@ -58,9 +58,9 @@ export default function PrivacyPolicy() {
             </p>
             <ul className="list-disc pl-6 text-gray-600 space-y-2 mb-4">
               <li>
-                <strong>Dados que você nos envia:</strong> ao preencher o formulário de interesse
-                no programa beta, coletamos nome, e-mail, empresa e a descrição do processo que
-                você deseja automatizar.
+                <strong>Dados que você nos envia:</strong> ao preencher o formulário da lista de
+                lançamento (programa beta), coletamos nome, e-mail, empresa e a descrição do
+                processo que você deseja automatizar.
               </li>
               <li>
                 <strong>Dados de navegação (anônimos):</strong> registramos eventos de uso do Site
@@ -81,8 +81,9 @@ export default function PrivacyPolicy() {
             <h2 className="text-2xl font-semibold text-gray-900 mb-4">3. Para que usamos e com qual base legal</h2>
             <ul className="list-disc pl-6 text-gray-600 space-y-2 mb-4">
               <li>
-                <strong>Responder ao seu interesse no beta:</strong> usamos os dados do formulário
-                para entrar em contato sobre o programa beta e avaliar o seu caso de uso. Base
+                <strong>Responder ao seu interesse no beta e no lançamento:</strong> usamos os
+                dados do formulário para avisar sobre o lançamento, entrar em contato sobre o
+                programa beta e avaliar o seu caso de uso. Base
                 legal: consentimento (art. 7º, I, LGPD) e procedimentos preliminares relacionados a
                 contrato (art. 7º, V, LGPD).
               </li>

--- a/src/components/BetaForm.tsx
+++ b/src/components/BetaForm.tsx
@@ -5,7 +5,7 @@ import { PLATFORM_BETA } from '@/lib/platform';
 import { CTA } from '@/lib/messages';
 import { track } from '@/lib/analytics';
 
-// Form da lista do beta — a captura primária do site (substitui o mailto;
+// Form da lista de lançamento — a captura primária do site (substitui o mailto;
 // PLATFORM_BETA vira fallback quando a entrega falha). POST em /api/beta.
 // Desenhado para viver dentro da seção .offer (fundo escuro).
 
@@ -55,8 +55,9 @@ export default function BetaForm() {
     return (
       <div className="bf bf-ok" role="status">
         <style>{BF_CSS}</style>
-        <b>Recebido!</b> O time entra em contato para montar o primeiro app operante com
-        você — sem cartão, sem compromisso.
+        <b>Você está na lista de lançamento!</b> Avisamos quando abrir — e, entre os
+        primeiros, o time entra em contato para montar o primeiro app operante com você.
+        Sem cartão, sem compromisso.
       </div>
     );
   }
@@ -135,7 +136,7 @@ export default function BetaForm() {
       <p className="bf-legal">
         Ao enviar, você concorda com os <a href="/terms">Termos de Uso</a> e a{' '}
         <a href="/privacidade">Política de Privacidade</a>, e em ser contatado sobre o
-        beta. Nada de spam.
+        lançamento e o beta. Nada de spam.
       </p>
     </form>
   );

--- a/src/lib/messages-en.ts
+++ b/src/lib/messages-en.ts
@@ -2,7 +2,7 @@
 // (PROPOSTA — aguardando martelo). One term only for the category:
 // "self-operating app". Do not invent copy outside the EN message house.
 
-export const SIGNATURE_EN = 'Delegate the task. Get the conclusion — with the proof.';
+export const SIGNATURE_EN = 'The app that works for your business — not the other way around.';
 
 export const PROMISE_EN =
   'An app that solves your problem and runs itself — integrated with what you already use, governed, live in weeks (not a months-long project).';
@@ -40,7 +40,7 @@ export const TRUST_RULES_EN = [
 ] as const;
 
 export const PHASE_EN = {
-  exists: 'Already real: the platform — 39 engines that build and operate real apps, multi-tenant, governed.',
+  exists: 'Already real: the platform — 39 engines that build and operate real apps, multi-tenant, governed. In private beta today; open launch coming soon.',
   next: 'Next chapter: dogfooding — Fluxomind running its own sales operation inside the product, the living proof that the agent operates and evolves.',
   vision: 'The vision: a catalog of self-operating apps created by experts — someone who has mastered a problem packages the method; your company installs it and adopts it already running.',
 } as const;

--- a/src/lib/messages.ts
+++ b/src/lib/messages.ts
@@ -1,7 +1,7 @@
 // Copy canônica compartilhada do site — fonte única (docs/message-house-cliente-final.md).
 // Strings que aparecem em mais de uma página vivem aqui; não duplicar nas páginas.
 
-export const SIGNATURE = 'Delegue a tarefa. Receba a conclusão com a prova.';
+export const SIGNATURE = 'App que trabalha para o seu negócio — não o contrário.';
 
 // Promessa ao cliente final (BCM-07, proposta de valor do lado empresa).
 export const PROMISE =
@@ -48,7 +48,7 @@ export const TRUST_RULES = [
 export const PHASE = {
   exists: {
     title: 'Já existe',
-    desc: 'A plataforma — 39 engines que materializam e operam apps de verdade, multi-tenant, governada.',
+    desc: 'A plataforma — 39 engines que materializam e operam apps de verdade, multi-tenant, governada. Hoje em beta privado; o lançamento aberto vem em breve.',
   },
   next: {
     title: 'Próximo capítulo',

--- a/src/lib/platform.ts
+++ b/src/lib/platform.ts
@@ -2,7 +2,7 @@
 //
 // MOTION (BCM-07 + decisão do fundador 2026-07-02): o site converte pelo
 // ENCANTAMENTO — a demonstração é o funil. CTA primário leva à demo (/#demo);
-// a decisão vira "Quero isso no meu negócio" (PLATFORM_BETA, lista do beta) ou
+// a decisão vira "Quero isso no meu negócio" (PLATFORM_BETA, lista de lançamento) ou
 // "Falar com o time" (PLATFORM_CONTACT). Free self-serve aberto NÃO é CTA
 // primário (BCM-07: free aberto queima inferência; o cliente chega high-intent).
 //


### PR DESCRIPTION
## O que muda

**Decisões do fundador (2026-07-07)** — emendas registradas em `docs/message-house-cliente-final.md` e `docs/message-house-en.md`:

1. **Estado público**: a plataforma ainda não está lançada — comunicar como **"beta privado · lançamento aberto em breve"** (EN: *private beta · open launch coming soon*), nunca "em breve" solto. Aplicado no badge do hero, /precos, /demo, FAQs e linhas de transparência (PHASE.exists) nas duas línguas.
2. **Lista de lançamento**: a captura primária (BetaForm) passa a formar o banco de interessados no lançamento — avisado quando abrir; os primeiros entram já no beta acompanhado, com o time montando o primeiro app junto. Termo canônico substitui "lista do beta" ("waitlist" segue vetado). Privacidade (pt/en) atualizada: finalidade inclui o aviso de lançamento.
3. **Nova assinatura (h1 canônico)**: *"App que trabalha para o seu negócio — não o contrário."* / *"The app that works for your business — not the other way around."* — substitui "Delegue a tarefa. Receba a conclusão com a prova." em h1, footers, kicks, title e OG.

## Verificação

- `tsc`, `lint` e `next build` limpos (30 rotas).
- Build de produção servido localmente: strings novas confirmadas em `/`, `/en`, `/precos`, `/en/pricing`, `/demo`, `/en/demo`; slogan antigo zerado no site (sobra só no registro histórico das emendas).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NPZMasVA9UKaAhKGkqr66G