### PR TITLE
QA de credibilidade — completa a reposição em prod (dogfood, demo, moeda EN, /plataforma)

### DIFF
--- a/src/app/app-operante/page.tsx
+++ b/src/app/app-operante/page.tsx
@@ -46,7 +46,7 @@ const FAQ = [
   },
   {
     q: 'Isso já existe ou é visão?',
-    a: 'A plataforma já existe — 39 engines que materializam e operam apps de verdade, multi-tenant, governada. Estamos em beta privado, com o lançamento aberto em breve: a adoção acontece acompanhada de perto pelo nosso time, em semanas, não num projeto de meses.',
+    a: 'A plataforma está construída e é software real — 39 engines em 10 camadas, multi-tenant e governada. Hoje em beta privado, com o lançamento aberto em breve: a adoção acontece acompanhada de perto pelo nosso time, em semanas, não num projeto de meses.',
   },
 ];
 

--- a/src/app/en/page.tsx
+++ b/src/app/en/page.tsx
@@ -123,19 +123,19 @@ export default function HomeEn() {
               <div className="fx-thread">
                 <div className="fx-bub fx-in">Hi! Do you still have the blue dress in size M? 👗</div>
                 <div className="fx-bub fx-out">
-                  We do, Camila! It&rsquo;s R$189 with free shipping today. Want me to reserve it and send the payment link?
+                  We do, Camila! It&rsquo;s $189 with free shipping today. Want me to reserve it and send the payment link?
                 </div>
                 <div className="fx-bub fx-in">Yes please! 🙌</div>
               </div>
               <div className="fx-run">
                 <div className="fx-r"><span className="fx-st done">Done</span> Replied to customer <time>23:47</time></div>
                 <div className="fx-r"><span className="fx-st done">Done</span> Order logged <time>23:48</time></div>
-                <div className="fx-r"><span className="fx-st pay">Paid</span> Payment confirmed · R$189 <time>23:52</time></div>
+                <div className="fx-r"><span className="fx-st pay">Paid</span> Payment confirmed · $189 <time>23:52</time></div>
               </div>
               <div className="fx-receipt">
                 <div className="fx-rh">This week&rsquo;s briefing</div>
-                <div className="fx-rbig fx-serif">R$12,480 <span>recovered</span></div>
-                <div className="fx-rsub">app cost: R$594 · return: <b>21×</b> · 0 customers left unanswered</div>
+                <div className="fx-rbig fx-serif">$12,480 <span>recovered</span></div>
+                <div className="fx-rsub">app cost: $594 · return: <b>21×</b> · 0 customers left unanswered</div>
               </div>
             </div>
           </div>

--- a/src/app/en/page.tsx
+++ b/src/app/en/page.tsx
@@ -216,9 +216,10 @@ export default function HomeEn() {
             gets copied; an invoice doesn&rsquo;t.
           </p>
           <p className="fx-body">
-            And we start with ourselves. Fluxomind runs its own sales operation inside the
-            product — we are <strong>customer zero</strong>. We operate our business with this
-            before asking you to operate yours.
+            And we start with ourselves. Before we open to the market, Fluxomind will run its own
+            business inside the product — billing, leads and WhatsApp support, all on Fluxomind.
+            That&rsquo;s our launch bar: we won&rsquo;t ask you to run your business on this until we run
+            ours on it. We&rsquo;re <strong>customer zero</strong>.
           </p>
         </div>
       </section>

--- a/src/app/en/self-operating-app/page.tsx
+++ b/src/app/en/self-operating-app/page.tsx
@@ -41,7 +41,7 @@ const FAQ_EN = [
   },
   {
     q: 'Is this real today, or a vision?',
-    a: 'The platform is real — 39 engines that materialize and operate real apps, multi-tenant, governed. We are in private beta, with the open launch coming soon: adoption happens closely guided by our team, in weeks, not a months-long project.',
+    a: 'The platform is built and it is real software — 39 engines across 10 layers, multi-tenant and governed. In private beta today, with the open launch coming soon: adoption happens closely guided by our team, in weeks, not a months-long project.',
   },
 ];
 

--- a/src/app/en/what-it-does/page.tsx
+++ b/src/app/en/what-it-does/page.tsx
@@ -148,7 +148,7 @@ export default function WhatItDoesEn() {
             <div className="fx-ft from">
               <h4>a code project you maintain</h4>
               <ul>
-                <li>Born from scratch &mdash; the code becomes your responsibility forever.</li>
+                <li>Handed to you as raw code &mdash; yours to maintain, forever.</li>
                 <li>Multi-tenant, roles, permissions? You implement them, or go without.</li>
                 <li>Every new request is more glued-on code; drift is a matter of time.</li>
                 <li>One surface only &mdash; a web page doesn&rsquo;t become WhatsApp or voice on its own.</li>

--- a/src/app/fx.css
+++ b/src/app/fx.css
@@ -54,6 +54,9 @@
 .fx .fx-btn-ghost:hover { color: #fff; }
 /* CTA do chrome (SiteHeader/MobileNav usam o botão globals .btn dentro do .fx) */
 .fx a.btn-primary { color: #fff; }
+/* o JourneyDemo (/demo) tem paleta própria; impedir que `.fx a` vaze nos links dele */
+.fx .jd a { color: inherit; text-decoration: none; }
+.fx a.jd-top-cta { color: #fff; }
 .fx-cta-row { display: flex; gap: 13px; flex-wrap: wrap; }
 .fx-tc .fx-cta-row { justify-content: center; }
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -220,9 +220,10 @@ export default function Home() {
             Funcionalidade se copia; fatura não.
           </p>
           <p className="fx-body">
-            E começamos por nós. A Fluxomind opera o próprio comercial dentro do produto — somos
-            o <strong>cliente nº 0</strong>. A gente opera o nosso negócio com isso antes de
-            pedir que você opere o seu.
+            E vamos começar por nós. Antes de abrir ao mercado, a Fluxomind vai operar o próprio
+            negócio dentro do produto — cobrança, leads e atendimento no WhatsApp, tudo na
+            Fluxomind. É o nosso critério de lançamento: a gente não pede que você opere o seu
+            negócio nisso antes de operar o nosso. O <strong>cliente nº 0</strong> é a gente.
           </p>
         </div>
       </section>

--- a/src/app/plataforma/page.tsx
+++ b/src/app/plataforma/page.tsx
@@ -364,184 +364,67 @@ export default function Plataforma() {
         </div>
       </section>
 
-      {/* 07 — QUALIDADE & CORREÇÃO */}
+
+      {/* 07 — FUNDAÇÃO VERIFICADA: governança, segurança e correção num só lugar; detalhe em /seguranca */}
       <section className="fx-sec fx-sec-alt">
         <div className="fx-wrap">
           <div className="fx-narrow">
-            <p className="fx-eyebrow">Qualidade &amp; correção</p>
-            <h2 className="fx-serif fx-h2">Correção verificada por máquina, não por confiança.</h2>
+            <p className="fx-eyebrow">Governança, segurança &amp; correção</p>
+            <h2 className="fx-serif fx-h2">Governança não é feature — é o produto.</h2>
             <p className="fx-body">
-              O princípio é confiança conquistada por evidência: a plataforma se verifica por
-              código — suítes que provam isolamento, integridade e contratos, não checklist.
+              Os limites vivem na arquitetura, não no código de cada app: a plataforma se verifica
+              por máquina, governa por política e protege na fundação — desde o primeiro dia, sem o
+              cliente configurar. É o que deixa um não-técnico delegar sem medo.
             </p>
             <span className="fx-badge b-impl">
-              <span className="fx-d" /> Implementado
+              <span className="fx-d" /> Núcleo já em produção
             </span>
           </div>
           <div className="fx-narrow fx-mt">
             <div className="fx-feat">
               <span className="fx-ck">{ICON_CK}</span>
               <div>
-                <h4>Invariantes de qualidade, verificados por máquina</h4>
+                <h4>Correção verificada por máquina</h4>
                 <p>
-                  Isolamento (probes cross-tenant + RLS via pgTAP), integridade, contratos,
-                  resiliência, compliance e evolvability. Boundaries, testes e gate de eval rodam
-                  sob demanda e no pipeline de deploy; a suíte de isolamento, em workflow dedicado.
+                  Suítes que provam isolamento (cross-tenant + RLS via pgTAP), integridade e
+                  contratos; qualidade de IA como gate (LLM-as-Judge) barra regressão antes de
+                  promover um fluxo.
                 </p>
-                <div className="fx-src">trilha: <code>validationEngine</code></div>
+                <div className="fx-src">trilha: <code>validationEngine</code> · <code>evalEngine</code></div>
               </div>
             </div>
             <div className="fx-feat">
               <span className="fx-ck">{ICON_CK}</span>
               <div>
-                <h4>Qualidade de IA como gate</h4>
+                <h4>Governança por arquitetura</h4>
                 <p>
-                  LLM-as-Judge e testes baseados em propriedade barram regressão antes de promover
-                  um fluxo.
+                  Política declarativa que o runtime aplica em toda a plataforma, com pessoa no
+                  circuito (HITL) nas ações sensíveis; cotas e entitlements por tenant.
                 </p>
-                <div className="fx-src">trilha: <code>evalEngine</code></div>
+                <div className="fx-src">trilha: <code>policyEngine</code> · <code>quotaEngine</code></div>
               </div>
             </div>
             <div className="fx-feat">
               <span className="fx-ck">{ICON_CK}</span>
               <div>
-                <h4>Contratos e testes</h4>
+                <h4>Segurança na fundação</h4>
                 <p>
-                  Contratos de API (OpenAPI) e de eventos (AsyncAPI) verificados; testes
-                  co-localizados ao código.
+                  Isolamento multi-tenant (schema dedicado + RLS), BYOK com crypto-shredding,
+                  masking de PII antes do LLM e trilha de auditoria SHA-256 à prova de adulteração.
                 </p>
-                <div className="fx-src">trilha: <code>validationEngine</code> · co-located tests</div>
+                <div className="fx-src">trilha: <code>securityEngine</code> · <code>auditTrailEngine</code></div>
               </div>
             </div>
           </div>
+          <p className="fx-body fx-narrow fx-mt">
+            O detalhe completo — as <strong>5 regras da confiança</strong> e o status honesto de
+            compliance (SOC2, pen-test externo) — vive em{' '}
+            <Link href="/seguranca">Segurança &amp; Governança →</Link>
+          </p>
         </div>
       </section>
 
-      {/* 08 — GOVERNANÇA */}
-      <section className="fx-sec">
-        <div className="fx-wrap">
-          <div className="fx-narrow">
-            <p className="fx-eyebrow">Governança</p>
-            <h2 className="fx-serif fx-h2">
-              Governança não é feature — é o produto.
-            </h2>
-            <p className="fx-body">
-              Limites na arquitetura, não no código de cada app: política declarativa que o runtime
-              aplica em toda a plataforma, com pessoa no circuito quando importa.
-            </p>
-            <span className="fx-badge b-parc">
-              <span className="fx-d" /> Parcial — núcleo implementado; self-service no roadmap
-            </span>
-          </div>
-          <div className="fx-narrow fx-mt">
-            <div className="fx-feat">
-              <span className="fx-ck">{ICON_CK}</span>
-              <div>
-                <h4>Políticas declarativas + HITL</h4>
-                <p>
-                  Guardrails versionados (checksum), avaliados com cache e explain; aprovação humana
-                  (human-in-the-loop) em ações sensíveis.
-                </p>
-                <div className="fx-src">trilha: <code>policyEngine</code></div>
-              </div>
-            </div>
-            <div className="fx-feat">
-              <span className="fx-ck">{ICON_CK}</span>
-              <div>
-                <h4>Cotas e entitlements</h4>
-                <p>
-                  Rate limiting, usage tracking e enforcement por tenant; reserva atômica e
-                  overrides aprovados.
-                </p>
-                <div className="fx-src">trilha: <code>quotaEngine</code></div>
-              </div>
-            </div>
-            <div className="fx-feat">
-              <span className="fx-ck">{ICON_CK}</span>
-              <div>
-                <h4>Consentimento e auditoria</h4>
-                <p>
-                  Ciclo de consentimento GDPR/LGPD e trilha de auditoria imutável por hash-chain
-                  (ver Segurança).
-                </p>
-                <div className="fx-src">
-                  trilha: <code>securityEngine</code> · <code>auditTrailEngine</code>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </section>
-
-      {/* 09 — SEGURANÇA */}
-      <section className="fx-sec fx-sec-alt">
-        <div className="fx-wrap">
-          <div className="fx-narrow">
-            <p className="fx-eyebrow">Segurança</p>
-            <h2 className="fx-serif fx-h2">Segurança e privacidade na fundação.</h2>
-            <p className="fx-body">
-              Multi-tenancy forte, criptografia e masking — desde o primeiro dia, sem o cliente
-              configurar. Capacidade de gente grande, entregue a quem não é técnico.
-            </p>
-            <span className="fx-badge b-impl">
-              <span className="fx-d" /> Implementado
-            </span>
-          </div>
-          <div className="fx-narrow fx-mt">
-            <div className="fx-feat">
-              <span className="fx-ck">{ICON_CK}</span>
-              <div>
-                <h4>BYOK — a chave é do cliente</h4>
-                <p>
-                  Traga a própria chave KMS (AWS/GCP/Azure). Crypto-shredding: revogou a chave, os
-                  dados ficam ilegíveis na hora — independente da plataforma.
-                </p>
-                <div className="fx-src">trilha: <code>securityEngine · spec-byok</code></div>
-              </div>
-            </div>
-            <div className="fx-feat">
-              <span className="fx-ck">{ICON_CK}</span>
-              <div>
-                <h4>Isolamento multi-tenant</h4>
-                <p>
-                  Schema dedicado por cliente + RLS como backstop. O{' '}
-                  <span className="fx-mono">tenantId</span> nunca vem do payload — deriva do contexto
-                  da requisição.
-                </p>
-                <div className="fx-src">
-                  trilha: <code>securityEngine</code> · <code>dataEngine</code>
-                </div>
-              </div>
-            </div>
-            <div className="fx-feat">
-              <span className="fx-ck">{ICON_CK}</span>
-              <div>
-                <h4>Masking de PII e content safety</h4>
-                <p>
-                  Dados sensíveis mascarados (4 estratégias) antes de chegar ao LLM; guardas contra
-                  prompt-injection e jailbreak.
-                </p>
-                <div className="fx-src">trilha: <code>securityEngine · spec-content-safety</code></div>
-              </div>
-            </div>
-            <div className="fx-feat">
-              <span className="fx-ck">{ICON_CK}</span>
-              <div>
-                <h4>Auth + audit hash-chain</h4>
-                <p>
-                  Dual token + RBAC; trilha SHA-256 append-only — adulteração é criptograficamente
-                  detectável e verificável por tenant.
-                </p>
-                <div className="fx-src">
-                  trilha: <code>securityEngine</code> · <code>auditTrailEngine · spec-hash-chain</code>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </section>
-
-      {/* 10 — DISTRIBUIÇÃO & CONEXÕES */}
+      {/* 08 — DISTRIBUIÇÃO & CONEXÕES */}
       <section className="fx-sec">
         <div className="fx-wrap">
           <div className="fx-narrow">


### PR DESCRIPTION
A reposição do site (identidade editorial-tech, pt+en) já está em `main`/produção. Este PR **completa** a entrega com os fixes de QA de credibilidade que ainda não estavam no ar.

## Fixes
- **Dogfood sem contradição** — a seção "A prova" da home (pt+en) reescrita como *critério de lançamento* (compromisso/futuro), alinhada à escada de honestidade. Antes o presente-tense ("a gente opera o nosso negócio com isso") contradizia o selo "próximo capítulo" na mesma página.
- **CTA da demo visível** — `.fx a` vazava no `JourneyDemo` e apagava o texto do botão da topbar (branco → azul sobre azul); escopado `.fx .jd a`. Vale para `/demo` e `/en/demo`.
- **Moeda EN em US$** — o feed ilustrativo da home EN de R$ → $ (1:1), preservando o múltiplo 21×.
- **`/plataforma` enxuta** — 3 seções de governança/segurança/correção consolidadas em 1 (12 → 9 seções), com a profundidade apontando para `/seguranca`.
- Também: calque "from scratch" removido do EN (message-house-en); FAQ dos engines sem overclaim de operação.

## Garantias
SEO preservado (canonical, hreflang, JSON-LD DefinedTerm/FAQPage), sem publicar preço, sem nomear concorrente, honestidade de estágio via badges. Build passa (38 rotas). Nenhum número inventado.

Commits: `e253b62` · `a8c1b6b` · `b83145b` · `d40a430`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D2JBpzrrU2Ep9F39PNsUd6
